### PR TITLE
[feat] 로그인 및 회원 CRUD 구현

### DIFF
--- a/user-server/build.gradle
+++ b/user-server/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	//JWT
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 
+	//Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compileOnly 'org.projectlombok:lombok'

--- a/user-server/src/main/java/com/quit/user/application/dto/TokenDto.java
+++ b/user-server/src/main/java/com/quit/user/application/dto/TokenDto.java
@@ -1,0 +1,9 @@
+package com.quit.user.application.dto;
+
+public record TokenDto(
+        String accessToken
+) {
+   public static TokenDto of(final String accessToken) {
+       return new TokenDto(accessToken);
+   }
+}

--- a/user-server/src/main/java/com/quit/user/common/filter/JwtAuthenticationFilter.java
+++ b/user-server/src/main/java/com/quit/user/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.quit.user.common.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.quit.user.application.dto.TokenDto;
+import com.quit.user.common.jwt.JwtUtil;
+import com.quit.user.common.security.UserDetailsImpl;
+import com.quit.user.domain.enums.UserRoleEnum;
+import com.quit.user.presentation.request.LoginRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtAuthenticationFilter  extends UsernamePasswordAuthenticationFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        setAuthenticationManager(authenticationManager);
+        setFilterProcessesUrl("/api/auth/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        log.info("로그인 시도");
+
+        try {
+            LoginRequest loginRequest = new ObjectMapper().readValue(request.getInputStream(), LoginRequest.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            loginRequest.email(),
+                            loginRequest.password(),
+                            null
+                    ));
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication auth) throws IOException {
+        log.info("로그인 성공 및 JWT 생성");
+        Long id = ((UserDetailsImpl)auth.getPrincipal()).getUser().getId();
+        UserRoleEnum role = ((UserDetailsImpl)auth.getPrincipal()).getUser().getRole();
+
+        TokenDto token = jwtUtil.createToken(id, role);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        String jsonResponse = new ObjectMapper().writeValueAsString(token);
+        response.getWriter().write(jsonResponse);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        log.info("로그인 실패");
+        response.setStatus(401);
+    }
+}

--- a/user-server/src/main/java/com/quit/user/common/filter/JwtAuthenticationFilter.java
+++ b/user-server/src/main/java/com/quit/user/common/filter/JwtAuthenticationFilter.java
@@ -51,10 +51,11 @@ public class JwtAuthenticationFilter  extends UsernamePasswordAuthenticationFilt
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication auth) throws IOException {
         log.info("로그인 성공 및 JWT 생성");
-        Long id = ((UserDetailsImpl)auth.getPrincipal()).getUser().getId();
+        String email = ((UserDetailsImpl)auth.getPrincipal()).getUser().getEmail();
         UserRoleEnum role = ((UserDetailsImpl)auth.getPrincipal()).getUser().getRole();
+        String nickname = ((UserDetailsImpl)auth.getPrincipal()).getUser().getNickname();
 
-        TokenDto token = jwtUtil.createToken(id, role);
+        TokenDto token = jwtUtil.createToken(email, role, nickname);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/user-server/src/main/java/com/quit/user/common/jwt/JwtUtil.java
+++ b/user-server/src/main/java/com/quit/user/common/jwt/JwtUtil.java
@@ -28,12 +28,13 @@ public class JwtUtil {
         this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
     }
 
-    public TokenDto createToken(Long id, UserRoleEnum role) {
+    public TokenDto createToken(String email, UserRoleEnum role, String nickname) {
 
         log.info("=========== 토큰 생성 시작 +++++++++++++++");
         return TokenDto.of(Jwts.builder()
-                .subject(String.valueOf(id))
+                .subject(email)
                 .claim("role", role)
+                .claim("nickname", nickname)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessExpiration))
                 .signWith(secretKey)

--- a/user-server/src/main/java/com/quit/user/common/jwt/JwtUtil.java
+++ b/user-server/src/main/java/com/quit/user/common/jwt/JwtUtil.java
@@ -1,0 +1,43 @@
+package com.quit.user.common.jwt;
+
+import com.quit.user.application.dto.TokenDto;
+import com.quit.user.domain.enums.UserRoleEnum;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+
+    private final SecretKey secretKey;
+
+    @Value(("${jwt.access-expiration}"))
+    private Long accessExpiration;
+
+    public static final Logger log = LoggerFactory.getLogger(JwtUtil.class);
+
+    public JwtUtil(@Value("${jwt.secret.key}")String secretKey) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
+    }
+
+    public TokenDto createToken(Long id, UserRoleEnum role) {
+
+        log.info("=========== 토큰 생성 시작 +++++++++++++++");
+        return TokenDto.of(Jwts.builder()
+                .subject(String.valueOf(id))
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+                .signWith(secretKey)
+                .compact());
+    }
+
+}

--- a/user-server/src/main/java/com/quit/user/common/security/UserDetailsImpl.java
+++ b/user-server/src/main/java/com/quit/user/common/security/UserDetailsImpl.java
@@ -1,0 +1,34 @@
+package com.quit.user.common.security;
+
+import com.quit.user.domain.model.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+}

--- a/user-server/src/main/java/com/quit/user/common/security/UserDetailsServiceImpl.java
+++ b/user-server/src/main/java/com/quit/user/common/security/UserDetailsServiceImpl.java
@@ -1,0 +1,30 @@
+package com.quit.user.common.security;
+
+import com.quit.user.domain.model.User;
+import com.quit.user.infrastructure.repository.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = (User) userRepository.findByEmail(username).orElseThrow(
+                () -> new UsernameNotFoundException(username));
+        return new UserDetailsImpl(user);
+    }
+
+}

--- a/user-server/src/main/java/com/quit/user/common/security/WebSecurityConfig.java
+++ b/user-server/src/main/java/com/quit/user/common/security/WebSecurityConfig.java
@@ -1,0 +1,51 @@
+package com.quit.user.common.security;
+
+import com.quit.user.common.filter.JwtAuthenticationFilter;
+import com.quit.user.common.jwt.JwtUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+
+    public WebSecurityConfig(JwtUtil jwtUtil, AuthenticationConfiguration authenticationConfiguration) {
+        this.jwtUtil = jwtUtil;
+        this.authenticationConfiguration = authenticationConfiguration;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        //csrf 보호 비활성화
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        http.authorizeHttpRequests((authorizationRequests) -> authorizationRequests
+                        .requestMatchers("/api/auth/login", "/api/auth/signup").permitAll() // 회원가입, 로그인 등에 대한 요청 접근 허용
+                .anyRequest().authenticated() )
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.addFilterAt(new JwtAuthenticationFilter(authenticationManager(authenticationConfiguration),jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+
+        return http.build();
+
+    }
+}

--- a/user-server/src/main/java/com/quit/user/domain/model/User.java
+++ b/user-server/src/main/java/com/quit/user/domain/model/User.java
@@ -54,7 +54,7 @@ public class User extends BaseEntity {
                               String phone,
                               String birthdate,
                               String address) {
-        return User.builder()
+        return com.quit.user.domain.model.User.builder()
                 .email(email)
                 .password(password)
                 .nickname(nickname)
@@ -63,5 +63,19 @@ public class User extends BaseEntity {
                 .birthdate(birthdate)
                 .address(address)
                 .build();
+    }
+
+    public void update(Long id,
+                       String email,
+                      String nickname,
+                      String phone,
+                      String birthdate,
+                      String address){
+        this.email = email;
+        this.nickname = nickname;
+        this.phone = phone;
+        this.birthdate = birthdate;
+        this.address = address;
+        markAsUpdated(String.valueOf(this.id));
     }
 }

--- a/user-server/src/main/java/com/quit/user/domain/service/AuthService.java
+++ b/user-server/src/main/java/com/quit/user/domain/service/AuthService.java
@@ -1,11 +1,16 @@
 package com.quit.user.domain.service;
 
+import com.quit.user.application.dto.TokenDto;
 import com.quit.user.application.dto.UserDto;
+import com.quit.user.common.jwt.JwtUtil;
 import com.quit.user.domain.model.User;
 import com.quit.user.infrastructure.repository.UserRepository;
+import com.quit.user.presentation.request.LoginRequest;
 import com.quit.user.presentation.request.SignupRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +20,8 @@ public class AuthService {
 
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final Logger log = LoggerFactory.getLogger(AuthService.class);
 
     public UserDto signup(@Valid SignupRequest signupRequest) {
         // 비밀번호 암호화
@@ -37,5 +44,24 @@ public class AuthService {
 
         return UserDto.of(user);
 
+    }
+
+    public TokenDto login(@Valid LoginRequest loginRequest) {
+
+        // 사용자 이메일 존재 여부 확인
+        User user = (User) userRepository.findByEmail(loginRequest.email()).orElseThrow(
+                () -> new IllegalArgumentException("아이디 혹은 비밀번호가 일치하지 않습니다.")
+        );
+
+        //비밀번호 확인
+        if (!passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
+            throw new IllegalArgumentException("아이디 혹은 비밀번호가 일치하지 않습니다.");
+        }
+
+        //토큰 발행
+        TokenDto token = jwtUtil.createToken(user.getId(), user.getRole());
+        log.info("======== 발행된 토큰 : " + token + "==================");
+
+        return token;
     }
 }

--- a/user-server/src/main/java/com/quit/user/domain/service/AuthService.java
+++ b/user-server/src/main/java/com/quit/user/domain/service/AuthService.java
@@ -46,22 +46,4 @@ public class AuthService {
 
     }
 
-    public TokenDto login(@Valid LoginRequest loginRequest) {
-
-        // 사용자 이메일 존재 여부 확인
-        User user = (User) userRepository.findByEmail(loginRequest.email()).orElseThrow(
-                () -> new IllegalArgumentException("아이디 혹은 비밀번호가 일치하지 않습니다.")
-        );
-
-        //비밀번호 확인
-        if (!passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
-            throw new IllegalArgumentException("아이디 혹은 비밀번호가 일치하지 않습니다.");
-        }
-
-        //토큰 발행
-        TokenDto token = jwtUtil.createToken(user.getId(), user.getRole());
-        log.info("======== 발행된 토큰 : " + token + "==================");
-
-        return token;
-    }
 }

--- a/user-server/src/main/java/com/quit/user/domain/service/UserService.java
+++ b/user-server/src/main/java/com/quit/user/domain/service/UserService.java
@@ -53,6 +53,6 @@ public class UserService {
         User user = userRepository.findById(id).orElseThrow(() ->
                 new IllegalArgumentException("해당하는 ID값을 갖는 사용자가 존재하지 않습니다."));
 
-        userRepository.delete(user);
+        user.markAsDeleted(String.valueOf(id));
     }
 }

--- a/user-server/src/main/java/com/quit/user/domain/service/UserService.java
+++ b/user-server/src/main/java/com/quit/user/domain/service/UserService.java
@@ -1,0 +1,58 @@
+package com.quit.user.domain.service;
+
+import com.quit.user.application.dto.UserDto;
+import com.quit.user.domain.model.User;
+import com.quit.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public List<UserDto> getUserList(){
+        List<User> users = userRepository.findAll();
+        List<UserDto> userDtos = new ArrayList<>();
+        for(User user : users){
+            userDtos.add(UserDto.of(user));
+        }
+
+        return userDtos;
+    }
+
+    public UserDto getUser(Long id) {
+        User user = userRepository.findById(id).orElseThrow(()
+                -> new IllegalArgumentException("해당하는 ID값을 갖는 사용자가 존재하지 않습니다."));
+
+        return UserDto.of(user);
+    }
+
+//    TODO
+//     - 수정하려고 하는 사용자정보가 현재 로그인된 사용자 본인인지 확인 로직 필요
+    @Transactional
+    public UserDto updateUser(Long id, UserDto userDto) {
+        User user = userRepository.findById(id).orElseThrow(() ->
+                new IllegalArgumentException("해당하는 ID값을 갖는 사용자가 존재하지 않습니다."));
+
+        user.update(id,
+                userDto.email(),
+                userDto.nickname(),
+                userDto.phone(),
+                userDto.birthdate(),
+                userDto.address());
+
+        return UserDto.of(user);
+    }
+    @Transactional
+    public void deleteUser(Long id) {
+        User user = userRepository.findById(id).orElseThrow(() ->
+                new IllegalArgumentException("해당하는 ID값을 갖는 사용자가 존재하지 않습니다."));
+
+        userRepository.delete(user);
+    }
+}

--- a/user-server/src/main/java/com/quit/user/infrastructure/config/PasswordEncoderConfig.java
+++ b/user-server/src/main/java/com/quit/user/infrastructure/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.quit.user.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/user-server/src/main/java/com/quit/user/presentation/controller/AuthController.java
+++ b/user-server/src/main/java/com/quit/user/presentation/controller/AuthController.java
@@ -30,15 +30,5 @@ public class AuthController {
                 .ok(ApiResponse.success(createdUser));
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenDto>> login(@Valid @RequestBody LoginRequest loginRequest) {
-
-        try {
-            TokenDto token = authService.login(loginRequest);
-            return ResponseEntity.ok(ApiResponse.success(token));
-        } catch (Exception e) {
-            throw new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.", e);
-        }
-    }
 }
 

--- a/user-server/src/main/java/com/quit/user/presentation/controller/AuthController.java
+++ b/user-server/src/main/java/com/quit/user/presentation/controller/AuthController.java
@@ -1,12 +1,13 @@
 package com.quit.user.presentation.controller;
 
+import com.quit.user.application.dto.TokenDto;
 import com.quit.user.application.dto.UserDto;
 import com.quit.user.common.dto.ApiResponse;
 import com.quit.user.domain.service.AuthService;
+import com.quit.user.presentation.request.LoginRequest;
 import com.quit.user.presentation.request.SignupRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,12 +22,23 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<?>> signup(@Valid @RequestBody SignupRequest signupRequest) {
+    public ResponseEntity<ApiResponse<UserDto>> signup(@Valid @RequestBody SignupRequest signupRequest) {
 
         UserDto createdUser = authService.signup(signupRequest);
 
         return ResponseEntity
                 .ok(ApiResponse.success(createdUser));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenDto>> login(@Valid @RequestBody LoginRequest loginRequest) {
+
+        try {
+            TokenDto token = authService.login(loginRequest);
+            return ResponseEntity.ok(ApiResponse.success(token));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.", e);
+        }
     }
 }
 

--- a/user-server/src/main/java/com/quit/user/presentation/controller/UserController.java
+++ b/user-server/src/main/java/com/quit/user/presentation/controller/UserController.java
@@ -1,0 +1,46 @@
+package com.quit.user.presentation.controller;
+
+import com.quit.user.application.dto.UserDto;
+import com.quit.user.common.dto.ApiResponse;
+import com.quit.user.domain.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+//    전체 사용자 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getUsers() {
+
+        return ResponseEntity.ok(ApiResponse.success(userService.getUserList()));
+    }
+
+//    특정 사용자 상세 정보 조회
+//    TODO
+//     - MASTER가 아닌 USER 권한의 사용자가 본인 정보 확인을 위한 사용자 본인 확인 로직 추가 필요
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<UserDto>> getUser(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.success(userService.getUser(id)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<UserDto>> updateUser(@PathVariable Long id, @RequestBody UserDto userDto) {
+        return ResponseEntity.ok(ApiResponse.success(userService.updateUser(id, userDto)));
+    }
+
+//    TODO
+//     - 삭제하려는 사용자 id와 현재 로그인된 사용자 id 일치 여부 확인 필요
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다."));
+    }
+}

--- a/user-server/src/main/java/com/quit/user/presentation/request/LoginRequest.java
+++ b/user-server/src/main/java/com/quit/user/presentation/request/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.quit.user.presentation.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record LoginRequest (
+        @NotBlank
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank
+        String password
+){
+}

--- a/user-server/src/main/resources/application.yml
+++ b/user-server/src/main/resources/application.yml
@@ -28,3 +28,9 @@ eureka:
 jwt:
   access-expiration: "#{60 * 60 * 1000}"
   secret-key: ${JWT_SECRET_KEY}
+
+logging:
+  level:
+    org:
+      springframework:
+        security=DEBUG:

--- a/user-server/src/main/resources/application.yml
+++ b/user-server/src/main/resources/application.yml
@@ -24,3 +24,7 @@ eureka:
   client:
     service-url:
       defaultZone: ${EUREKA_SERVICE_URL}
+
+jwt:
+  access-expiration: "#{60 * 60 * 1000}"
+  secret-key: ${JWT_SECRET_KEY}

--- a/user-server/userTest.http
+++ b/user-server/userTest.http
@@ -4,11 +4,11 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "email":"user5@email.com",
-  "password" :"User5555@",
-  "nickname":"사용자5",
-  "phone":"010-5555-5555",
-  "birthdate":"2000-05-05"
+  "email":"user6@email.com",
+  "password" :"User6666@",
+  "nickname":"사용자6",
+  "phone":"010-6666-6666",
+  "birthdate":"2000-06-06"
 }
 
 ###로그인

--- a/user-server/userTest.http
+++ b/user-server/userTest.http
@@ -1,12 +1,49 @@
-#회원 가입
+###회원 가입
 POST http://host.docker.internal:19092/api/auth/signup
 Content-Type: application/json
 Accept: application/json
 
 {
-  "email":"user2@email.com",
-  "password" :"User2222@",
-  "nickname":"사용자2",
-  "phone":"010-2222-2222",
-  "birthdate":"2000-01-01"
+  "email":"user5@email.com",
+  "password" :"User5555@",
+  "nickname":"사용자5",
+  "phone":"010-5555-5555",
+  "birthdate":"2000-05-05"
 }
+
+###로그인
+POST http://host.docker.internal:19092/api/auth/login
+Content-Type: application/json
+Accept: application/json
+
+{
+"email":"user5@email.com",
+"password" :"User5555@"
+}
+
+###사용자 전체 조회
+GET http://host.docker.internal:19092/api/users
+Content-Type: application/json
+Accept: application/json
+
+###특정 사용자 조회
+GET http://host.docker.internal:19092/api/users/1
+Content-Type: application/json
+Accept: application/json
+
+###회원 정보 수정
+PUT http://host.docker.internal:19092/api/users/1
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email":"user1@email.com",
+  "nickname":"갈매기살항정살",
+  "phone":"010-1111-4444",
+  "birthdate":"2000-05-05"
+}
+
+###사용자 탈퇴
+DELETE http://host.docker.internal:19092/api/users/152
+Content-Type: application/json
+Accept: application/json


### PR DESCRIPTION
## #️⃣연관된 이슈

> #22 

## 📝작업 내용

> 로그인, 회원 정보 조회, 수정, 삭제 구현
> userTest.http 업데이트

### 스크린샷

## 💬리뷰 요구사항

> 추후 로그인을 비지니스 로직과의 분리를 고민하고 있습니다.
   filter 추가 후 필요한 작업을 TODO로 표시해두었습니다.