### PR TITLE
[feat] 예약스케줄 생성, 수정, 삭제, 조회 기능 구현

### DIFF
--- a/store/src/main/java/com/quit/store/application/dto/ReservationSlotDto.java
+++ b/store/src/main/java/com/quit/store/application/dto/ReservationSlotDto.java
@@ -1,0 +1,35 @@
+package com.quit.store.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationSlotDto {
+
+    private LocalDate date;
+    private LocalTime time;
+    private Integer maxCapacity;
+
+    @Builder
+    private ReservationSlotDto(LocalDate date, LocalTime time, Integer maxCapacity) {
+        this.date = date;
+        this.time = time;
+        this.maxCapacity = maxCapacity;
+    }
+
+    public static ReservationSlotDto of(LocalDate date, LocalTime time, Integer maxCapacity) {
+        return ReservationSlotDto.builder()
+                .date(date)
+                .time(time)
+                .maxCapacity(maxCapacity)
+                .build();
+
+    }
+
+}

--- a/store/src/main/java/com/quit/store/application/dto/UpdateReservationSlotDto.java
+++ b/store/src/main/java/com/quit/store/application/dto/UpdateReservationSlotDto.java
@@ -1,0 +1,40 @@
+package com.quit.store.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateReservationSlotDto {
+
+    private LocalDate date;
+    private LocalTime time;
+    private Integer maxCapacity;
+    private Boolean isAvailable;
+
+    @Builder
+    private UpdateReservationSlotDto(LocalDate date, LocalTime time,
+                                     Integer maxCapacity, Boolean isAvailable) {
+        this.date = date;
+        this.time = time;
+        this.maxCapacity = maxCapacity;
+        this.isAvailable = isAvailable;
+    }
+
+    public static UpdateReservationSlotDto of(LocalDate date, LocalTime time,
+                                              Integer maxCapacity, Boolean isAvailable) {
+        return UpdateReservationSlotDto.builder()
+                .date(date)
+                .time(time)
+                .maxCapacity(maxCapacity)
+                .isAvailable(isAvailable)
+                .build();
+
+    }
+
+}

--- a/store/src/main/java/com/quit/store/application/dto/res/ReservationSlotResponse.java
+++ b/store/src/main/java/com/quit/store/application/dto/res/ReservationSlotResponse.java
@@ -1,0 +1,64 @@
+package com.quit.store.application.dto.res;
+
+import com.quit.store.domain.entity.ReservationSlot;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationSlotResponse {
+    private UUID storeId;
+    private UUID slotId;
+    private LocalDate date;
+    private LocalTime time;
+    private Boolean isAvailable;
+    private Integer maxCapacity;
+    private Integer currentCapacity;
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime updatedAt;
+    private String updatedBy;
+
+    @Builder
+    private ReservationSlotResponse(UUID storeId, UUID slotId,
+                                    LocalDate date, LocalTime time, Boolean isAvailable,
+                                   Integer maxCapacity, Integer currentCapacity,
+                                   LocalDateTime createdAt, String createdBy,
+                                   LocalDateTime updatedAt, String updatedBy) {
+        this.storeId = storeId;
+        this.slotId = slotId;
+        this.date = date;
+        this.time = time;
+        this.isAvailable = isAvailable;
+        this.maxCapacity = maxCapacity;
+        this.currentCapacity = currentCapacity;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+    }
+
+    public static ReservationSlotResponse from(ReservationSlot reservationSlot) {
+        return ReservationSlotResponse.builder()
+                .storeId(reservationSlot.getStore().getId())
+                .slotId(reservationSlot.getId())
+                .date(reservationSlot.getDate())
+                .time(reservationSlot.getTime())
+                .isAvailable(reservationSlot.getIsAvailable())
+                .maxCapacity(reservationSlot.getMaxCapacity())
+                .currentCapacity(reservationSlot.getCurrentCapacity())
+                .createdAt(reservationSlot.getCreatedAt())
+                .createdBy(reservationSlot.getCreatedBy())
+                .updatedAt(reservationSlot.getUpdatedAt())
+                .updatedBy(reservationSlot.getUpdatedBy())
+                .build();
+    }
+
+}

--- a/store/src/main/java/com/quit/store/application/dto/res/StoreResponse.java
+++ b/store/src/main/java/com/quit/store/application/dto/res/StoreResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
@@ -23,12 +24,18 @@ public class StoreResponse {
     private LocalTime closeTime;
     private LocalTime lastOrderTime;
     private Category category;
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime updatedAt;
+    private String updatedBy;
 
     @Builder
     private StoreResponse(UUID id, String name, String description, String address,
                           String contactNumber, Integer reservationDeposit,
                           LocalTime openTime, LocalTime closeTime,
-                          LocalTime lastOrderTime, Category category) {
+                          LocalTime lastOrderTime, Category category,
+                          LocalDateTime createdAt, String createdBy,
+                          LocalDateTime updatedAt, String updatedBy) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -39,6 +46,10 @@ public class StoreResponse {
         this.closeTime = closeTime;
         this.lastOrderTime = lastOrderTime;
         this.category = category;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
     }
 
     public static StoreResponse from(Store store) {
@@ -53,6 +64,10 @@ public class StoreResponse {
                 .closeTime(store.getCloseTime())
                 .lastOrderTime(store.getLastOrderTime())
                 .category(store.getCategory())
+                .createdAt(store.getCreatedAt())
+                .createdBy(store.getCreatedBy())
+                .updatedAt(store.getUpdatedAt())
+                .updatedBy(store.getUpdatedBy())
                 .build();
     }
 

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -9,6 +9,8 @@ import com.quit.store.domain.repository.ReservationSlotRepository;
 import com.quit.store.domain.repository.StoreRepository;
 import com.quit.store.presentation.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +49,13 @@ public class ReservationSlotService {
         validateMaxCapacity(slot, request.getMaxCapacity());
         slot.update(request);
         return ReservationSlotResponse.from(slot);
+    }
+
+    public Page<ReservationSlotResponse> getSlotsByStore(UUID storeId, Pageable pageable) {
+        Store store = checkStore(storeId);
+        Page<ReservationSlot> reservationSlotPage =
+                reservationSlotRepository.findByStoreAndIsDeletedFalseAndIsAvailableTrue(store, pageable);
+        return reservationSlotPage.map(ReservationSlotResponse::from);
     }
 
     public void deleteSlot(UUID storeId, UUID slotId, String userId) {

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -89,19 +89,19 @@ public class ReservationSlotService {
 
     private void validateMaxCapacity(ReservationSlot slot, Integer maxCapacity) {
         if(maxCapacity != null && maxCapacity < slot.getCurrentCapacity()) {
-            throw new CustomException(RESERVATION_SLOT_MAX_CAPACITY_INVALID);
+            throw new CustomException(RESERVATION_SLOT_MAX_CAPACITY_NOT_ALLOWED);
         }
     }
 
     private void validateTime(ReservationSlot slot, LocalTime time) {
         if(slot.getCurrentCapacity() > 0 && time != null && !time.equals(slot.getTime())) {
-            throw new CustomException(RESERVATION_SLOT_TIME_CHANGE_NOT_ALLOWED);
+            throw new CustomException(RESERVATION_SLOT_TIME_NOT_ALLOWED);
         }
     }
 
     private void validateDate(ReservationSlot slot, LocalDate date) {
         if(slot.getCurrentCapacity() > 0 && date != null && !date.equals(slot.getDate())) {
-            throw new CustomException(RESERVATION_SLOT_DATE_CHANGE_NOT_ALLOWED);
+            throw new CustomException(RESERVATION_SLOT_DATE_NOT_ALLOWED);
         }
     }
 

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -51,11 +51,19 @@ public class ReservationSlotService {
         return ReservationSlotResponse.from(slot);
     }
 
+    @Transactional(readOnly = true)
     public Page<ReservationSlotResponse> getSlotsByStore(UUID storeId, Pageable pageable) {
         Store store = checkStore(storeId);
-        Page<ReservationSlot> reservationSlotPage =
-                reservationSlotRepository.findByStoreAndIsDeletedFalseAndIsAvailableTrue(store, pageable);
+        Page<ReservationSlot> reservationSlotPage = reservationSlotRepository.findByStoreId(store.getId(), pageable);
         return reservationSlotPage.map(ReservationSlotResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public ReservationSlotResponse getSlotByDateAndTime(UUID storeId, LocalDate date, LocalTime time) {
+        Store store = checkStore(storeId);
+        ReservationSlot slot = reservationSlotRepository.findByDateAndTime(store.getId(), date, time)
+                .orElseThrow(() -> new CustomException(RESERVATION_SLOT_NOT_FOUND));
+        return ReservationSlotResponse.from(slot);
     }
 
     public void deleteSlot(UUID storeId, UUID slotId, String userId) {

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -39,6 +39,7 @@ public class ReservationSlotService {
         // todo: 권한체크로직
         Store store = checkStore(storeId);
         ReservationSlot slot = checkSlot(slotId);
+        validateSlotBelongsToStore(store.getId(), slot);
         // 1. 현재 currentCapacity > 0 일 때 날짜, 시간 변경 X
         // 2. maxCapacity 가 현재 currentCapacity 보다 작을 경우 변경 X
         validateDate(slot, request.getDate());
@@ -46,6 +47,27 @@ public class ReservationSlotService {
         validateMaxCapacity(slot, request.getMaxCapacity());
         slot.update(request);
         return ReservationSlotResponse.from(slot);
+    }
+
+    public void deleteSlot(UUID storeId, UUID slotId, String userId) {
+        // todo: 권한체크로직
+        Store store = checkStore(storeId);
+        ReservationSlot slot = checkSlot(slotId);
+        validateSlotBelongsToStore(store.getId(), slot);
+        validateReservation(slot);
+        slot.delete(userId);
+    }
+
+    private void validateSlotBelongsToStore(UUID storeId, ReservationSlot slot) {
+        if (!slot.getStore().getId().equals(storeId)) {
+            throw new CustomException(RESERVATION_SLOT_STORE_MISMATCH);
+        }
+    }
+
+    private void validateReservation(ReservationSlot slot) {
+        if(slot.getCurrentCapacity() > 0) {
+            throw new CustomException(RESERVATION_SLOT_DELETE_NOT_ALLOWED);
+        }
     }
 
     private void validateMaxCapacity(ReservationSlot slot, Integer maxCapacity) {

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -1,0 +1,48 @@
+package com.quit.store.application.service;
+
+import com.quit.store.application.dto.ReservationSlotDto;
+import com.quit.store.application.dto.res.ReservationSlotResponse;
+import com.quit.store.domain.entity.ReservationSlot;
+import com.quit.store.domain.entity.Store;
+import com.quit.store.domain.repository.ReservationSlotRepository;
+import com.quit.store.domain.repository.StoreRepository;
+import com.quit.store.presentation.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.quit.store.presentation.exception.ErrorType.STORE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReservationSlotService {
+
+    private final ReservationSlotRepository reservationSlotRepository;
+    private final StoreRepository storeRepository;
+
+    public ReservationSlotResponse createSlot(UUID storeId, ReservationSlotDto request, String userId) {
+        // todo: 권한체크로직
+        Store store = checkStore(storeId);
+        ReservationSlot slot = create(store, request);
+        reservationSlotRepository.save(slot);
+        return ReservationSlotResponse.from(slot);
+    }
+
+    private ReservationSlot create(Store store, ReservationSlotDto request) {
+        return ReservationSlot.of(
+                request.getDate(),
+                request.getTime(),
+                request.getMaxCapacity(),
+                store
+        );
+    }
+
+    private Store checkStore(UUID storeId) {
+        return storeRepository.findByIdAndIsDeletedFalse(storeId)
+                .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+    }
+
+}

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -1,6 +1,7 @@
 package com.quit.store.application.service;
 
 import com.quit.store.application.dto.ReservationSlotDto;
+import com.quit.store.application.dto.UpdateReservationSlotDto;
 import com.quit.store.application.dto.res.ReservationSlotResponse;
 import com.quit.store.domain.entity.ReservationSlot;
 import com.quit.store.domain.entity.Store;
@@ -11,9 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.UUID;
 
-import static com.quit.store.presentation.exception.ErrorType.STORE_NOT_FOUND;
+import static com.quit.store.presentation.exception.ErrorType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +34,38 @@ public class ReservationSlotService {
         return ReservationSlotResponse.from(slot);
     }
 
+    public ReservationSlotResponse updateSlot(UUID storeId, UUID slotId,
+                                              UpdateReservationSlotDto request, String userId) {
+        // todo: 권한체크로직
+        Store store = checkStore(storeId);
+        ReservationSlot slot = checkSlot(slotId);
+        // 1. 현재 currentCapacity > 0 일 때 날짜, 시간 변경 X
+        // 2. maxCapacity 가 현재 currentCapacity 보다 작을 경우 변경 X
+        validateDate(slot, request.getDate());
+        validateTime(slot, request.getTime());
+        validateMaxCapacity(slot, request.getMaxCapacity());
+        slot.update(request);
+        return ReservationSlotResponse.from(slot);
+    }
+
+    private void validateMaxCapacity(ReservationSlot slot, Integer maxCapacity) {
+        if(maxCapacity != null && maxCapacity < slot.getCurrentCapacity()) {
+            throw new CustomException(RESERVATION_SLOT_MAX_CAPACITY_INVALID);
+        }
+    }
+
+    private void validateTime(ReservationSlot slot, LocalTime time) {
+        if(slot.getCurrentCapacity() > 0 && time != null && !time.equals(slot.getTime())) {
+            throw new CustomException(RESERVATION_SLOT_TIME_CHANGE_NOT_ALLOWED);
+        }
+    }
+
+    private void validateDate(ReservationSlot slot, LocalDate date) {
+        if(slot.getCurrentCapacity() > 0 && date != null && !date.equals(slot.getDate())) {
+            throw new CustomException(RESERVATION_SLOT_DATE_CHANGE_NOT_ALLOWED);
+        }
+    }
+
     private ReservationSlot create(Store store, ReservationSlotDto request) {
         return ReservationSlot.of(
                 request.getDate(),
@@ -43,6 +78,11 @@ public class ReservationSlotService {
     private Store checkStore(UUID storeId) {
         return storeRepository.findByIdAndIsDeletedFalse(storeId)
                 .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+    }
+
+    private ReservationSlot checkSlot(UUID slotId) {
+        return reservationSlotRepository.findByIdAndIsDeletedFalse(slotId)
+                .orElseThrow(() -> new CustomException(RESERVATION_SLOT_NOT_FOUND));
     }
 
 }

--- a/store/src/main/java/com/quit/store/domain/entity/ReservationSlot.java
+++ b/store/src/main/java/com/quit/store/domain/entity/ReservationSlot.java
@@ -1,5 +1,6 @@
 package com.quit.store.domain.entity;
 
+import com.quit.store.application.dto.UpdateReservationSlotDto;
 import com.quit.store.common.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -57,6 +58,37 @@ public class ReservationSlot extends BaseEntity {
                 .maxCapacity(maxCapacity)
                 .store(store)
                 .build();
+    }
+
+    public void update(UpdateReservationSlotDto request) {
+        updateDate(request.getDate());
+        updateTime(request.getTime());
+        updateMaxCapacity(request.getMaxCapacity());
+        updateIsAvailable(request.getIsAvailable());
+    }
+
+    private void updateDate(LocalDate date) {
+        if (date != null) {
+            this.date = date;
+        }
+    }
+
+    private void updateTime(LocalTime time) {
+        if (time != null) {
+            this.time = time;
+        }
+    }
+
+    private void updateMaxCapacity(Integer maxCapacity) {
+        if (maxCapacity != null) {
+            this.maxCapacity = maxCapacity;
+        }
+    }
+
+    private void updateIsAvailable(Boolean isAvailable) {
+        if (isAvailable != null) {
+            this.isAvailable = isAvailable;
+        }
     }
 
 }

--- a/store/src/main/java/com/quit/store/domain/entity/ReservationSlot.java
+++ b/store/src/main/java/com/quit/store/domain/entity/ReservationSlot.java
@@ -1,0 +1,62 @@
+package com.quit.store.domain.entity;
+
+import com.quit.store.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_reservation_slot")
+public class ReservationSlot extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "time", nullable = false)
+    private LocalTime time;
+
+    @Column(name = "is_available", nullable = false)
+    private Boolean isAvailable = true;
+
+    @Column(name = "max_capacity", nullable = false)
+    private Integer maxCapacity;
+
+    @Column(name = "current_capacity", nullable = false)
+    private Integer currentCapacity = 0;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Builder
+    private ReservationSlot(LocalDate date, LocalTime time,
+                            Integer maxCapacity, Store store) {
+        this.date = date;
+        this.time = time;
+        this.maxCapacity = maxCapacity;
+        this.store = store;
+    }
+
+    public static ReservationSlot of(LocalDate date, LocalTime time,
+                                     Integer maxCapacity, Store store) {
+        return ReservationSlot.builder()
+                .date(date)
+                .time(time)
+                .maxCapacity(maxCapacity)
+                .store(store)
+                .build();
+    }
+
+}

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
@@ -1,11 +1,18 @@
 package com.quit.store.domain.repository;
 
 import com.quit.store.domain.entity.ReservationSlot;
+import com.quit.store.domain.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ReservationSlotRepository extends JpaRepository<ReservationSlot, UUID> {
+
     Optional<ReservationSlot> findByIdAndIsDeletedFalse(UUID slotId);
+
+    Page<ReservationSlot> findByStoreAndIsDeletedFalseAndIsAvailableTrue(Store store, Pageable pageable);
+
 }

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
@@ -1,0 +1,9 @@
+package com.quit.store.domain.repository;
+
+import com.quit.store.domain.entity.ReservationSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReservationSlotRepository extends JpaRepository<ReservationSlot, UUID> {
+}

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
@@ -1,18 +1,13 @@
 package com.quit.store.domain.repository;
 
 import com.quit.store.domain.entity.ReservationSlot;
-import com.quit.store.domain.entity.Store;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface ReservationSlotRepository extends JpaRepository<ReservationSlot, UUID> {
+public interface ReservationSlotRepository extends JpaRepository<ReservationSlot, UUID>, ReservationSlotRepositoryCustom {
 
     Optional<ReservationSlot> findByIdAndIsDeletedFalse(UUID slotId);
-
-    Page<ReservationSlot> findByStoreAndIsDeletedFalseAndIsAvailableTrue(Store store, Pageable pageable);
 
 }

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepository.java
@@ -3,7 +3,9 @@ package com.quit.store.domain.repository;
 import com.quit.store.domain.entity.ReservationSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ReservationSlotRepository extends JpaRepository<ReservationSlot, UUID> {
+    Optional<ReservationSlot> findByIdAndIsDeletedFalse(UUID slotId);
 }

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryCustom.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.quit.store.domain.repository;
+
+import com.quit.store.domain.entity.ReservationSlot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ReservationSlotRepositoryCustom {
+    Page<ReservationSlot> findByStoreId(UUID storeId, Pageable pageable);
+    Optional<ReservationSlot> findByDateAndTime(UUID storeId, LocalDate date, LocalTime time);
+}

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryImpl.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryImpl.java
@@ -1,0 +1,81 @@
+package com.quit.store.domain.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.quit.store.domain.entity.ReservationSlot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.quit.store.domain.entity.QReservationSlot.reservationSlot;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ReservationSlotRepositoryImpl implements ReservationSlotRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<ReservationSlot> findByStoreId(UUID storeId, Pageable pageable) {
+
+        List<ReservationSlot> slotList = jpaQueryFactory
+                .selectFrom(reservationSlot)
+                .where(
+                        storeEq(storeId),
+                        reservationSlot.isAvailable.eq(true),
+                        reservationSlot.isDeleted.eq(false)
+                )
+                .orderBy(reservationSlot.store.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(reservationSlot.count())
+                .from(reservationSlot)
+                .where(
+                        storeEq(storeId),
+                        reservationSlot.isAvailable.eq(true),
+                        reservationSlot.isDeleted.eq(false)
+                );
+
+        return PageableExecutionUtils.getPage(slotList, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Optional<ReservationSlot> findByDateAndTime(UUID storeId, LocalDate date, LocalTime time) {
+        ReservationSlot slot = jpaQueryFactory
+                .selectFrom(reservationSlot)
+                .where(
+                        storeEq(storeId),
+                        dateEq(date),
+                        timeEq(time),
+                        reservationSlot.isAvailable.eq(true),
+                        reservationSlot.isDeleted.eq(false)
+                )
+                .fetchOne();
+        return Optional.ofNullable(slot);
+    }
+
+    private BooleanExpression timeEq(LocalTime time) {
+        return time != null ? reservationSlot.time.eq(time) : null;
+    }
+
+    private BooleanExpression dateEq(LocalDate date) {
+        return date != null ? reservationSlot.date.eq(date) : null;
+    }
+
+    private BooleanExpression storeEq(UUID storeId) {
+        return storeId != null ? reservationSlot.store.id.eq(storeId) : null;
+    }
+
+}

--- a/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
@@ -1,0 +1,35 @@
+package com.quit.store.presentation.controller;
+
+import com.quit.store.application.dto.res.ReservationSlotResponse;
+import com.quit.store.application.service.ReservationSlotService;
+import com.quit.store.common.dto.ApiResponse;
+import com.quit.store.presentation.dto.CreateReservationSlotRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stores/{storeId}/reservation-slots")
+public class ReservationSlotController {
+
+    private final ReservationSlotService reservationSlotService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReservationSlotResponse>> createSlot(@PathVariable(name = "storeId") UUID storeId,
+            @Valid @RequestBody CreateReservationSlotRequest request) {
+
+        // todo:
+        //  1. 게이트웨이 구현 후 @RequestHeader(name = "X-user-id") String userId 로 수정
+        //  2. @RequestHeader(name = "X-user-role") String userRole 추가
+
+        String userId = "testUserId";
+        return ResponseEntity.ok(ApiResponse.success(reservationSlotService.createSlot(storeId, request.toDto(), userId)));
+    }
+
+
+
+}

--- a/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
@@ -4,6 +4,7 @@ import com.quit.store.application.dto.res.ReservationSlotResponse;
 import com.quit.store.application.service.ReservationSlotService;
 import com.quit.store.common.dto.ApiResponse;
 import com.quit.store.presentation.dto.CreateReservationSlotRequest;
+import com.quit.store.presentation.dto.UpdateReservationSlotRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,11 +26,20 @@ public class ReservationSlotController {
         // todo:
         //  1. 게이트웨이 구현 후 @RequestHeader(name = "X-user-id") String userId 로 수정
         //  2. @RequestHeader(name = "X-user-role") String userRole 추가
-
         String userId = "testUserId";
         return ResponseEntity.ok(ApiResponse.success(reservationSlotService.createSlot(storeId, request.toDto(), userId)));
     }
 
+    @PutMapping("/{slotId}")
+    public ResponseEntity<ApiResponse<ReservationSlotResponse>> updateSlot(@PathVariable(name = "storeId") UUID storeId,
+                                                                           @PathVariable(name = "slotId") UUID slotId,
+                                                                           @RequestBody UpdateReservationSlotRequest request) {
+        // todo:
+        //  1. 게이트웨이 구현 후 @RequestHeader(name = "X-user-id") String userId 로 수정
+        //  2. @RequestHeader(name = "X-user-role") String userRole 추가
+        String userId = "testUserId";
+        return ResponseEntity.ok(ApiResponse.success(reservationSlotService.updateSlot(storeId, slotId, request.toDto(), userId)));
+    }
 
 
 }

--- a/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
@@ -41,5 +41,16 @@ public class ReservationSlotController {
         return ResponseEntity.ok(ApiResponse.success(reservationSlotService.updateSlot(storeId, slotId, request.toDto(), userId)));
     }
 
+    @DeleteMapping("/{slotId}")
+    public ResponseEntity<ApiResponse<String>> deleteSlot(@PathVariable(name = "storeId") UUID storeId,
+                                                          @PathVariable(name = "slotId") UUID slotId) {
+        // todo:
+        //  1. 게이트웨이 구현 후 @RequestHeader(name = "X-user-id") String userId 로 수정
+        //  2. @RequestHeader(name = "X-user-role") String userRole 추가
+        String userId = "testUserId";
+        reservationSlotService.deleteSlot(storeId, slotId, userId);
+        return ResponseEntity.ok(ApiResponse.success("삭제가 완료되었습니다."));
+    }
+
 
 }

--- a/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
@@ -3,13 +3,17 @@ package com.quit.store.presentation.controller;
 import com.quit.store.application.dto.res.ReservationSlotResponse;
 import com.quit.store.application.service.ReservationSlotService;
 import com.quit.store.common.dto.ApiResponse;
+import com.quit.store.common.util.PageableUtil;
 import com.quit.store.presentation.dto.CreateReservationSlotRequest;
 import com.quit.store.presentation.dto.UpdateReservationSlotRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -39,6 +43,16 @@ public class ReservationSlotController {
         //  2. @RequestHeader(name = "X-user-role") String userRole 추가
         String userId = "testUserId";
         return ResponseEntity.ok(ApiResponse.success(reservationSlotService.updateSlot(storeId, slotId, request.toDto(), userId)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<ReservationSlotResponse>>> getSlotsByStore(@PathVariable(name = "storeId") UUID storeId,
+                                                                                      @RequestParam(defaultValue = "1") int page,
+                                                                                      @RequestParam(defaultValue = "10") int size,
+                                                                                      @RequestParam(defaultValue = "createdAt") String sortBy,
+                                                                                      @RequestParam(defaultValue = "false") boolean isAsc) {
+        Pageable pageable = PageableUtil.createPageableWithSorting(page, size, sortBy, isAsc);
+        return ResponseEntity.ok(ApiResponse.success(reservationSlotService.getSlotsByStore(storeId, pageable)));
     }
 
     @DeleteMapping("/{slotId}")

--- a/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
@@ -7,13 +7,15 @@ import com.quit.store.common.util.PageableUtil;
 import com.quit.store.presentation.dto.CreateReservationSlotRequest;
 import com.quit.store.presentation.dto.UpdateReservationSlotRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.UUID;
 
 @RestController
@@ -53,6 +55,13 @@ public class ReservationSlotController {
                                                                                       @RequestParam(defaultValue = "false") boolean isAsc) {
         Pageable pageable = PageableUtil.createPageableWithSorting(page, size, sortBy, isAsc);
         return ResponseEntity.ok(ApiResponse.success(reservationSlotService.getSlotsByStore(storeId, pageable)));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<ReservationSlotResponse>> getSlotByDateAndTime(@PathVariable(name = "storeId") UUID storeId,
+                                                                                     @RequestParam LocalDate date,
+                                                                                     @RequestParam LocalTime time) {
+        return ResponseEntity.ok(ApiResponse.success(reservationSlotService.getSlotByDateAndTime(storeId, date, time)));
     }
 
     @DeleteMapping("/{slotId}")

--- a/store/src/main/java/com/quit/store/presentation/dto/CreateReservationSlotRequest.java
+++ b/store/src/main/java/com/quit/store/presentation/dto/CreateReservationSlotRequest.java
@@ -1,0 +1,28 @@
+package com.quit.store.presentation.dto;
+
+import com.quit.store.application.dto.ReservationSlotDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateReservationSlotRequest {
+
+    private LocalDate date;
+    private LocalTime time;
+    private Integer maxCapacity;
+
+    public ReservationSlotDto toDto() {
+        return ReservationSlotDto.of(
+                this.date,
+                this.time,
+                this.maxCapacity
+        );
+    }
+
+}

--- a/store/src/main/java/com/quit/store/presentation/dto/CreateReservationSlotRequest.java
+++ b/store/src/main/java/com/quit/store/presentation/dto/CreateReservationSlotRequest.java
@@ -14,16 +14,15 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateReservationSlotRequest {
-    //todo: validation message 작성
 
-    @NotNull
+    @NotNull(message = "RESERVATION_SLOT_DATE_EMPTY")
     private LocalDate date;
 
-    @NotNull
+    @NotNull(message = "RESERVATION_SLOT_TIME_EMPTY")
     private LocalTime time;
 
-    @NotNull
-    @Positive
+    @NotNull(message = "RESERVATION_SLOT_MAX_CAPACITY_EMPTY")
+    @Positive(message = "RESERVATION_SLOT_MAX_CAPACITY_INVALID")
     private Integer maxCapacity;
 
     public ReservationSlotDto toDto() {

--- a/store/src/main/java/com/quit/store/presentation/dto/UpdateReservationSlotRequest.java
+++ b/store/src/main/java/com/quit/store/presentation/dto/UpdateReservationSlotRequest.java
@@ -1,8 +1,7 @@
 package com.quit.store.presentation.dto;
 
 import com.quit.store.application.dto.ReservationSlotDto;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import com.quit.store.application.dto.UpdateReservationSlotDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,24 +12,19 @@ import java.time.LocalTime;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateReservationSlotRequest {
-    //todo: validation message 작성
+public class UpdateReservationSlotRequest {
 
-    @NotNull
     private LocalDate date;
-
-    @NotNull
     private LocalTime time;
-
-    @NotNull
-    @Positive
     private Integer maxCapacity;
+    private Boolean isAvailable;
 
-    public ReservationSlotDto toDto() {
-        return ReservationSlotDto.of(
+    public UpdateReservationSlotDto toDto() {
+        return UpdateReservationSlotDto.of(
                 this.date,
                 this.time,
-                this.maxCapacity
+                this.maxCapacity,
+                this.isAvailable
         );
     }
 

--- a/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
+++ b/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
@@ -26,6 +26,12 @@ public enum ErrorType {
     STORE_CLOSE_TIME_EMPTY(BAD_REQUEST, "가게 마감 시간이 존재하지 않습니다."),
     STORE_LAST_ORDER_TIME_EMPTY(BAD_REQUEST, "가게 주문 마감 시간이 존재하지 않습니다."),
     STORE_CATEGORY_EMPTY(BAD_REQUEST, "가게 카테고리가 존재하지 않습니다."),
+
+    RESERVATION_SLOT_NOT_FOUND(NOT_FOUND, "예약 스케줄이 존재하지 않습니다."),
+    RESERVATION_SLOT_DATE_CHANGE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 날짜를 변경할 수 없습니다."),
+    RESERVATION_SLOT_TIME_CHANGE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 시간을 변경할 수 없습니다."),
+    RESERVATION_SLOT_MAX_CAPACITY_INVALID(BAD_REQUEST, "최대 예약 가능 인원이 현재 예약된 인원보다 적을 수 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
+++ b/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
@@ -28,11 +28,15 @@ public enum ErrorType {
     STORE_CATEGORY_EMPTY(BAD_REQUEST, "가게 카테고리가 존재하지 않습니다."),
 
     RESERVATION_SLOT_NOT_FOUND(NOT_FOUND, "예약 스케줄이 존재하지 않습니다."),
-    RESERVATION_SLOT_DATE_CHANGE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 날짜를 변경할 수 없습니다."),
-    RESERVATION_SLOT_TIME_CHANGE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 시간을 변경할 수 없습니다."),
-    RESERVATION_SLOT_MAX_CAPACITY_INVALID(BAD_REQUEST, "최대 예약 가능 인원이 현재 예약된 인원보다 적을 수 없습니다."),
+    RESERVATION_SLOT_DATE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 날짜를 변경할 수 없습니다."),
+    RESERVATION_SLOT_TIME_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 시간을 변경할 수 없습니다."),
+    RESERVATION_SLOT_MAX_CAPACITY_NOT_ALLOWED(BAD_REQUEST, "최대 예약 가능 인원이 현재 예약된 인원보다 적을 수 없습니다."),
     RESERVATION_SLOT_DELETE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 예약 슬롯을 삭제할 수 없습니다."),
     RESERVATION_SLOT_STORE_MISMATCH(BAD_REQUEST, "예약 스케줄이 요청된 가게에 속하지 않습니다."),
+    RESERVATION_SLOT_DATE_EMPTY(BAD_REQUEST, "예약 스케줄 날짜가 존재하지 않습니다."),
+    RESERVATION_SLOT_TIME_EMPTY(BAD_REQUEST, "예약 스케줄 시간이 존재하지 않습니다."),
+    RESERVATION_SLOT_MAX_CAPACITY_EMPTY(BAD_REQUEST, "예약스케줄 최대 예약 가능 인원이 존재하지 않습니다."),
+    RESERVATION_SLOT_MAX_CAPACITY_INVALID(BAD_REQUEST, "예약스케줄 최대 예약 가능 인원이 유효하지 않습니다."),
 
     ;
 

--- a/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
+++ b/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
@@ -31,6 +31,8 @@ public enum ErrorType {
     RESERVATION_SLOT_DATE_CHANGE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 날짜를 변경할 수 없습니다."),
     RESERVATION_SLOT_TIME_CHANGE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 시간을 변경할 수 없습니다."),
     RESERVATION_SLOT_MAX_CAPACITY_INVALID(BAD_REQUEST, "최대 예약 가능 인원이 현재 예약된 인원보다 적을 수 없습니다."),
+    RESERVATION_SLOT_DELETE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 예약 슬롯을 삭제할 수 없습니다."),
+    RESERVATION_SLOT_STORE_MISMATCH(BAD_REQUEST, "예약 스케줄이 요청된 가게에 속하지 않습니다."),
 
     ;
 

--- a/store/src/main/java/com/quit/store/presentation/exception/GlobalExceptionHandler.java
+++ b/store/src/main/java/com/quit/store/presentation/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -57,6 +58,14 @@ public class GlobalExceptionHandler {
             return createResponseEntity(customException.getErrorType());
         }
         return createResponseEntity(INTERNAL_SERVER_ERROR, ErrorType.COMMON_SERVER_ERROR.name(), e.getMessage());
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<CustomErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        logError(e);
+        String parameterName = e.getParameterName();
+        String errorMessage = String.format("필수 요청 파라미터인 '%s' 가 존재하지 않습니다.", parameterName);
+        return createResponseEntity(BAD_REQUEST, ErrorType.COMMON_INVALID_PARAMETER.name(), errorMessage);
     }
 
     private ErrorType errorMessageToErrorCode(String errorMessage, ErrorType defaultErrorCode) {


### PR DESCRIPTION
## #️⃣연관된 이슈
close #26 

## 📝작업 내용
- 예약스케줄 관련 CRUD 기능 구현
    - 예약 스케줄 조회
        - 특정 가게의 예약 스케줄 조회
        - 특정 날짜와 시간의 예약 스케줄 조회
    - 예약 수정 및 삭제 조건은 아래와 같습니다.
        - 예약이 없는 예약 스케줄만 수정 및 삭제 가능
        - currentCapacity > 0 이면 변경 X
        - maxCapacity 가 현재 currentCapacity 보다 작을 경우 변경 X

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
