### PR TITLE
[feat] 결제 서비스 kafka 적용

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 	// log4j2
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+
+	//kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 dependencyManagement {

--- a/payment/docker-compose.yml
+++ b/payment/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    platform: linux/amd64
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: wurstmeister/kafka:latest
+    platform: linux/amd64
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:29092,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_READONLY: "false"

--- a/payment/src/main/java/com/quit/payment/application/dto/PaymentEvent.java
+++ b/payment/src/main/java/com/quit/payment/application/dto/PaymentEvent.java
@@ -10,17 +10,20 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaymentEvent {
+    private UUID reservationId;
     private UUID paymentId;
     private Integer amount;
 
     @Builder
-    private PaymentEvent(UUID paymentId, Integer amount) {
+    private PaymentEvent(UUID reservationId, UUID paymentId, Integer amount) {
+        this.reservationId = reservationId;
         this.paymentId = paymentId;
         this.amount = amount;
     }
 
-    public static PaymentEvent of(UUID paymentId, Integer amount) {
+    public static PaymentEvent of(UUID reservationId, UUID paymentId, Integer amount) {
         return PaymentEvent.builder()
+                .reservationId(reservationId)
                 .paymentId(paymentId)
                 .amount(amount)
                 .build();

--- a/payment/src/main/java/com/quit/payment/application/dto/PaymentEvent.java
+++ b/payment/src/main/java/com/quit/payment/application/dto/PaymentEvent.java
@@ -1,0 +1,29 @@
+package com.quit.payment.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentEvent {
+    private UUID paymentId;
+    private Integer amount;
+
+    @Builder
+    private PaymentEvent(UUID paymentId, Integer amount) {
+        this.paymentId = paymentId;
+        this.amount = amount;
+    }
+
+    public static PaymentEvent of(UUID paymentId, Integer amount) {
+        return PaymentEvent.builder()
+                .paymentId(paymentId)
+                .amount(amount)
+                .build();
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -1,6 +1,7 @@
 package com.quit.payment.application.service;
 
 import com.quit.payment.application.dto.PaymentDto;
+import com.quit.payment.application.dto.PaymentEvent;
 import com.quit.payment.application.dto.TempPaymentDto;
 import com.quit.payment.application.dto.res.PaymentResponse;
 import com.quit.payment.application.dto.res.TempPaymentResponse;
@@ -9,13 +10,12 @@ import com.quit.payment.domain.entity.Status;
 import com.quit.payment.domain.entity.TempPayment;
 import com.quit.payment.domain.repository.PaymentRepository;
 import com.quit.payment.domain.repository.TempPaymentRepository;
-import com.quit.payment.infrastructure.client.PaymentClient;
 import com.quit.payment.infrastructure.client.PaymentGateway;
 import com.quit.payment.infrastructure.dto.CancelPaymentResponse;
 import com.quit.payment.infrastructure.dto.ConfirmPaymentResponse;
+import com.quit.payment.infrastructure.kafka.KafkaProducer;
 import com.quit.payment.presentation.dto.CancelPaymentRequest;
 import com.quit.payment.presentation.exception.CustomException;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,6 +35,9 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final TempPaymentRepository tempPaymentRepository;
     private final PaymentGateway paymentGateway;
+    private final KafkaProducer kafkaProducer;
+    private static final String PAYMENT_CREATE_SUCCESS = "payment.create.success";
+    private static final String PAYMENT_CREATE_FAILED = "payment.create.failed";
 
     public TempPaymentResponse createTempPayment(TempPaymentDto request) {
         TempPayment tempPayment = TempPayment.of(request.getAmount(), request.getOrderId());
@@ -42,18 +45,17 @@ public class PaymentService {
         return TempPaymentResponse.from(tempPayment);
     }
 
-    public PaymentResponse createPayment(PaymentDto request) {
+    public PaymentResponse createPayment(UUID reservationId, PaymentDto request) {
         TempPayment tempPayment = ValidatePayment(request.getOrderId());
         validateAmount(tempPayment, request.getAmount());
         ConfirmPaymentResponse response = paymentGateway.confirmPayment(request);
         log.info("Confirm payment response: {}", response);
-        /* todo:
-            1. kafka 적용 후 예약 생성 구독해 예약 id 가져오기
-            2. 결제 생성 후 메세지 발행하기
-         */
-        UUID reservationId = UUID.randomUUID();
         Payment payment = create(response, reservationId);
         paymentRepository.save(payment);
+        kafkaProducer.sendMessage(
+                PAYMENT_CREATE_SUCCESS,
+                payment.getId().toString(),
+                PaymentEvent.of(payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }
 
@@ -61,10 +63,12 @@ public class PaymentService {
         Payment payment = checkPayment(paymentsId);
         CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);
-        /* todo:
-            1. kafka 적용 결제 취소 후 메세지 발행하기
-         */
         payment.cancel(Status.CANCELED, request.getCancelReason());
+        kafkaProducer.sendMessage(
+                PAYMENT_CREATE_FAILED,
+                payment.getId().toString(),
+                PaymentEvent.of(payment.getId(), payment.getAmount())
+        );
         return PaymentResponse.from(payment);
     }
 

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -38,8 +38,8 @@ public class PaymentService {
     private final ReservationGateway reservationGateway;
     private final PaymentGateway paymentGateway;
     private final KafkaProducer kafkaProducer;
-    private static final String PAYMENT_CREATE_SUCCESS = "payment.create.success";
-    private static final String PAYMENT_CREATE_FAILED = "payment.create.failed";
+    private static final String PAYMENT_SUCCESS_TOPIC = "payment.create.success";
+    private static final String PAYMENT_FAILED_TOPIC = "payment.create.failed";
 
     public TempPaymentResponse createTempPayment(TempPaymentDto request) {
         TempPayment tempPayment = TempPayment.of(request.getAmount(), request.getOrderId());
@@ -56,7 +56,7 @@ public class PaymentService {
         log.info("Confirm payment response: {}", response);
         Payment payment = create(response, reservationResponse.getReservationId());
         paymentRepository.save(payment);
-        sendKafkaMessage(PAYMENT_CREATE_SUCCESS,"paymentId:" + payment.getId(), PaymentEvent.of(reservationResponse.getReservationId(), payment.getId(), payment.getAmount()));
+        sendKafkaMessage(PAYMENT_SUCCESS_TOPIC,"paymentId:" + payment.getId(), PaymentEvent.of(reservationResponse.getReservationId(), payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }
 
@@ -65,7 +65,7 @@ public class PaymentService {
         CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);
         payment.cancel(Status.CANCELED, request.getCancelReason());
-        sendKafkaMessage(PAYMENT_CREATE_FAILED, "paymentId:" + payment.getId(), PaymentEvent.of(payment.getReservationId(), payment.getId(), payment.getAmount()));
+        sendKafkaMessage(PAYMENT_FAILED_TOPIC, "paymentId:" + payment.getId(), PaymentEvent.of(payment.getReservationId(), payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }
 

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -11,8 +11,10 @@ import com.quit.payment.domain.entity.TempPayment;
 import com.quit.payment.domain.repository.PaymentRepository;
 import com.quit.payment.domain.repository.TempPaymentRepository;
 import com.quit.payment.infrastructure.client.PaymentGateway;
+import com.quit.payment.infrastructure.client.ReservationGateway;
 import com.quit.payment.infrastructure.dto.CancelPaymentResponse;
 import com.quit.payment.infrastructure.dto.ConfirmPaymentResponse;
+import com.quit.payment.infrastructure.dto.ReservationResponse;
 import com.quit.payment.infrastructure.kafka.KafkaProducer;
 import com.quit.payment.presentation.dto.CancelPaymentRequest;
 import com.quit.payment.presentation.exception.CustomException;
@@ -23,8 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
-import static com.quit.payment.presentation.exception.ErrorType.PAYMENT_DATA_INVALID;
-import static com.quit.payment.presentation.exception.ErrorType.PAYMENT_NOT_FOUND;
+import static com.quit.payment.presentation.exception.ErrorType.*;
 
 @Slf4j
 @Service
@@ -34,6 +35,7 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final TempPaymentRepository tempPaymentRepository;
+    private final ReservationGateway reservationGateway;
     private final PaymentGateway paymentGateway;
     private final KafkaProducer kafkaProducer;
     private static final String PAYMENT_CREATE_SUCCESS = "payment.create.success";
@@ -48,20 +50,24 @@ public class PaymentService {
     public PaymentResponse createPayment(UUID reservationId, PaymentDto request) {
         TempPayment tempPayment = ValidatePayment(request.getOrderId());
         validateAmount(tempPayment, request.getAmount());
+        // todo: errorDecoder 로 예외처리, fallbackmethod 처리
+        ReservationResponse reservationResponse = reservationGateway.getReservation(reservationId).getData();
+        log.info("reservationId= {}", reservationResponse.getReservationId());
         ConfirmPaymentResponse response = paymentGateway.confirmPayment(request);
         log.info("Confirm payment response: {}", response);
-        Payment payment = create(response, reservationId);
+        Payment payment = create(response, reservationResponse.getReservationId());
         paymentRepository.save(payment);
         String key = "paymentId:" + payment.getId();
         kafkaProducer.sendMessage(
                 PAYMENT_CREATE_SUCCESS,
                 key,
-                PaymentEvent.of(reservationId, payment.getId(), payment.getAmount()));
+                PaymentEvent.of(reservationResponse.getReservationId(), payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }
 
     public PaymentResponse cancelPayment(UUID paymentsId, UUID reservationId, CancelPaymentRequest request) {
         Payment payment = checkPayment(paymentsId);
+        checkReservation(payment, reservationId);
         CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);
         payment.cancel(Status.CANCELED, request.getCancelReason());
@@ -72,6 +78,13 @@ public class PaymentService {
                 PaymentEvent.of(reservationId, payment.getId(), payment.getAmount())
         );
         return PaymentResponse.from(payment);
+    }
+
+    private void checkReservation(Payment payment, UUID reservationId) {
+        if(!payment.getReservationId().equals(reservationId)) {
+            throw new CustomException(RESERVATION_ID_MISMATCH);
+        }
+
     }
 
     @Transactional(readOnly = true)

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -65,8 +65,8 @@ public class PaymentService {
         return PaymentResponse.from(payment);
     }
 
-    public PaymentResponse cancelPayment(UUID paymentsId, UUID reservationId, CancelPaymentRequest request) {
-        Payment payment = checkPayment(paymentsId);
+    public PaymentResponse cancelPayment(UUID paymentId, UUID reservationId, CancelPaymentRequest request) {
+        Payment payment = checkPayment(paymentId);
         checkReservation(payment, reservationId);
         CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -55,11 +55,11 @@ public class PaymentService {
         kafkaProducer.sendMessage(
                 PAYMENT_CREATE_SUCCESS,
                 payment.getId().toString(),
-                PaymentEvent.of(payment.getId(), payment.getAmount()));
+                PaymentEvent.of(reservationId, payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }
 
-    public PaymentResponse cancelPayment(UUID paymentsId, CancelPaymentRequest request) {
+    public PaymentResponse cancelPayment(UUID paymentsId, UUID reservationId, CancelPaymentRequest request) {
         Payment payment = checkPayment(paymentsId);
         CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);
@@ -67,7 +67,7 @@ public class PaymentService {
         kafkaProducer.sendMessage(
                 PAYMENT_CREATE_FAILED,
                 payment.getId().toString(),
-                PaymentEvent.of(payment.getId(), payment.getAmount())
+                PaymentEvent.of(reservationId, payment.getId(), payment.getAmount())
         );
         return PaymentResponse.from(payment);
     }

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -48,8 +48,7 @@ public class PaymentService {
     }
 
     public PaymentResponse createPayment(UUID reservationId, PaymentDto request) {
-        TempPayment tempPayment = ValidatePayment(request.getOrderId());
-        validateAmount(tempPayment, request.getAmount());
+        TempPayment tempPayment = validateTempPayment(request);
         // todo: errorDecoder 로 예외처리, fallbackmethod 처리
         ReservationResponse reservationResponse = reservationGateway.getReservation(reservationId).getData();
         log.info("reservationId= {}", reservationResponse.getReservationId());
@@ -57,34 +56,17 @@ public class PaymentService {
         log.info("Confirm payment response: {}", response);
         Payment payment = create(response, reservationResponse.getReservationId());
         paymentRepository.save(payment);
-        String key = "paymentId:" + payment.getId();
-        kafkaProducer.sendMessage(
-                PAYMENT_CREATE_SUCCESS,
-                key,
-                PaymentEvent.of(reservationResponse.getReservationId(), payment.getId(), payment.getAmount()));
+        sendKafkaMessage(PAYMENT_CREATE_SUCCESS,"paymentId:" + payment.getId(), PaymentEvent.of(reservationResponse.getReservationId(), payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }
 
     public PaymentResponse cancelPayment(UUID paymentId, UUID reservationId, CancelPaymentRequest request) {
-        Payment payment = checkPayment(paymentId);
-        checkReservation(payment, reservationId);
+        Payment payment = validatePayment(paymentId, reservationId);
         CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);
         payment.cancel(Status.CANCELED, request.getCancelReason());
-        String key = "paymentId:" + payment.getId();
-        kafkaProducer.sendMessage(
-                PAYMENT_CREATE_FAILED,
-                key,
-                PaymentEvent.of(reservationId, payment.getId(), payment.getAmount())
-        );
+        sendKafkaMessage(PAYMENT_CREATE_FAILED, "paymentId:" + payment.getId(), PaymentEvent.of(payment.getReservationId(), payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
-    }
-
-    private void checkReservation(Payment payment, UUID reservationId) {
-        if(!payment.getReservationId().equals(reservationId)) {
-            throw new CustomException(RESERVATION_ID_MISMATCH);
-        }
-
     }
 
     @Transactional(readOnly = true)
@@ -94,8 +76,21 @@ public class PaymentService {
         return PaymentResponse.from(payment);
     }
 
-    private Payment checkPayment(UUID paymentsId) {
-        return paymentRepository.findByIdAndIsDeletedFalse(paymentsId).orElseThrow(() -> new CustomException(PAYMENT_NOT_FOUND));
+    private TempPayment validateTempPayment(PaymentDto request) {
+        TempPayment tempPayment = checkTempPayment(request);
+        validateAmount(tempPayment, request.getAmount());
+        return tempPayment;
+    }
+
+    private TempPayment checkTempPayment(PaymentDto request) {
+        return tempPaymentRepository.findByOrderIdAndIsDeletedFalse(request.getOrderId())
+                .orElseThrow(() -> new CustomException(PAYMENT_DATA_INVALID));
+    }
+
+    private void validateAmount(TempPayment tempPayment, Integer amount) {
+        if(!tempPayment.getAmount().equals(amount)) {
+            throw new CustomException(PAYMENT_DATA_INVALID);
+        }
     }
 
     private Payment create(ConfirmPaymentResponse response, UUID reservationId) {
@@ -107,15 +102,30 @@ public class PaymentService {
                 reservationId);
     }
 
-    private void validateAmount(TempPayment tempPayment, Integer amount) {
-        if(!tempPayment.getAmount().equals(amount)) {
-            throw new CustomException(PAYMENT_DATA_INVALID);
+    private Payment validatePayment(UUID paymentId, UUID reservationId) {
+        Payment payment = checkPayment(paymentId);
+        validateReservation(payment, reservationId);
+        return payment;
+    }
+
+    private Payment checkPayment(UUID paymentsId) {
+        return paymentRepository.findByIdAndIsDeletedFalse(paymentsId)
+                .orElseThrow(() -> new CustomException(PAYMENT_NOT_FOUND));
+    }
+
+    private void validateReservation(Payment payment, UUID reservationId) {
+        if(!payment.getReservationId().equals(reservationId)) {
+            throw new CustomException(RESERVATION_ID_MISMATCH);
         }
     }
 
-    private TempPayment ValidatePayment(String orderId) {
-        return tempPaymentRepository.findByOrderIdAndIsDeletedFalse(orderId)
-                .orElseThrow(() -> new CustomException(PAYMENT_DATA_INVALID));
+    private void sendKafkaMessage(String topic, String key, PaymentEvent event) {
+        try {
+            kafkaProducer.sendMessage(topic, key, event);
+        } catch (Exception e) {
+            log.error("Failed to send Kafka message: topic= {}, key= {}", topic, key);
+            throw new CustomException(KAFKA_MESSAGE_SEND_FAILED);
+        }
     }
 
 }

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -52,9 +52,10 @@ public class PaymentService {
         log.info("Confirm payment response: {}", response);
         Payment payment = create(response, reservationId);
         paymentRepository.save(payment);
+        String key = "paymentId:" + payment.getId();
         kafkaProducer.sendMessage(
                 PAYMENT_CREATE_SUCCESS,
-                payment.getId().toString(),
+                key,
                 PaymentEvent.of(reservationId, payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }
@@ -64,9 +65,10 @@ public class PaymentService {
         CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);
         payment.cancel(Status.CANCELED, request.getCancelReason());
+        String key = "paymentId:" + payment.getId();
         kafkaProducer.sendMessage(
                 PAYMENT_CREATE_FAILED,
-                payment.getId().toString(),
+                key,
                 PaymentEvent.of(reservationId, payment.getId(), payment.getAmount())
         );
         return PaymentResponse.from(payment);

--- a/payment/src/main/java/com/quit/payment/domain/entity/Payment.java
+++ b/payment/src/main/java/com/quit/payment/domain/entity/Payment.java
@@ -35,7 +35,7 @@ public class Payment extends BaseEntity {
     @Column(name = "cancel_reason")
     private String cancelReason;
 
-    @Column(name = "reservation_id", nullable = false)
+    @Column(name = "reservation_id", nullable = false, unique = true)
     private UUID reservationId;
 
     @Builder

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentClient.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentClient.java
@@ -1,7 +1,7 @@
 package com.quit.payment.infrastructure.client;
 
 import com.quit.payment.application.dto.PaymentDto;
-import com.quit.payment.configuration.PaymentFeignConfig;
+import com.quit.payment.infrastructure.configuration.PaymentFeignConfig;
 import com.quit.payment.infrastructure.dto.CancelPaymentResponse;
 import com.quit.payment.infrastructure.dto.ConfirmPaymentResponse;
 import com.quit.payment.presentation.dto.CancelPaymentRequest;

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/ReservationClient.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/ReservationClient.java
@@ -1,0 +1,17 @@
+package com.quit.payment.infrastructure.client;
+
+import com.quit.payment.common.dto.ApiResponse;
+import com.quit.payment.infrastructure.dto.ReservationResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "reservation", url = "http://localhost:19094")
+public interface ReservationClient {
+
+    @GetMapping(value = "/api/reservations/{reservationId}")
+    ApiResponse<ReservationResponse> getReservation(@PathVariable(name = "reservationId") UUID reservationId);
+
+}

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/ReservationGateway.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/ReservationGateway.java
@@ -1,0 +1,11 @@
+package com.quit.payment.infrastructure.client;
+
+import com.quit.payment.common.dto.ApiResponse;
+import com.quit.payment.infrastructure.dto.ReservationResponse;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+public interface ReservationGateway {
+    ApiResponse<ReservationResponse> getReservation(@PathVariable(name = "reservationId") UUID reservationId);
+}

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/ReservationGatewayImpl.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/ReservationGatewayImpl.java
@@ -1,0 +1,21 @@
+package com.quit.payment.infrastructure.client;
+
+import com.quit.payment.common.dto.ApiResponse;
+import com.quit.payment.infrastructure.dto.ReservationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationGatewayImpl implements ReservationGateway {
+
+    private final ReservationClient reservationClient;
+
+    @Override
+    public ApiResponse<ReservationResponse> getReservation(UUID reservationId) {
+        return reservationClient.getReservation(reservationId);
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/infrastructure/configuration/AuditorAwareImpl.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/configuration/AuditorAwareImpl.java
@@ -1,4 +1,4 @@
-package com.quit.payment.configuration;
+package com.quit.payment.infrastructure.configuration;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.NonNull;

--- a/payment/src/main/java/com/quit/payment/infrastructure/configuration/JpaConfig.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/configuration/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.quit.payment.configuration;
+package com.quit.payment.infrastructure.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/payment/src/main/java/com/quit/payment/infrastructure/configuration/PaymentAuthInterceptor.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/configuration/PaymentAuthInterceptor.java
@@ -1,4 +1,4 @@
-package com.quit.payment.configuration;
+package com.quit.payment.infrastructure.configuration;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;

--- a/payment/src/main/java/com/quit/payment/infrastructure/configuration/PaymentFeignConfig.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/configuration/PaymentFeignConfig.java
@@ -1,4 +1,4 @@
-package com.quit.payment.configuration;
+package com.quit.payment.infrastructure.configuration;
 
 import feign.Logger;
 import feign.Request;

--- a/payment/src/main/java/com/quit/payment/infrastructure/configuration/PaymentProperties.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/configuration/PaymentProperties.java
@@ -1,4 +1,4 @@
-package com.quit.payment.configuration;
+package com.quit.payment.infrastructure.configuration;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/payment/src/main/java/com/quit/payment/infrastructure/dto/ReservationResponse.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/dto/ReservationResponse.java
@@ -1,0 +1,21 @@
+package com.quit.payment.infrastructure.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Getter
+@ToString
+public class ReservationResponse {
+    private UUID reservationId;
+    private String customerId;
+    private UUID storeId;
+    private Integer guestCount;
+    private LocalDate reservationDate;
+    private LocalTime reservationTime;
+    private String reservationStatus;
+    private Integer reservationPrice;
+}

--- a/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProducer.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProducer.java
@@ -1,0 +1,17 @@
+package com.quit.payment.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendMessage(String topic, String key, Object message) {
+        kafkaTemplate.send(topic, key, message);
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProducerConfig.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProducerConfig.java
@@ -18,7 +18,7 @@ public class KafkaProducerConfig {
     private final KafkaProperties kafkaProperties;
 
     @Bean
-    public ProducerFactory<String, String> producerFactory() {
+    public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
@@ -27,7 +27,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, String> kafkaTemplate() {
+    public KafkaTemplate<String, Object> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 

--- a/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProducerConfig.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package com.quit.payment.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getValueSerializer());
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProperties.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/kafka/KafkaProperties.java
@@ -1,0 +1,24 @@
+package com.quit.payment.infrastructure.kafka;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.kafka")
+public class KafkaProperties {
+
+    private String bootstrapServers;
+    private Producer producer = new Producer();
+
+    @Getter
+    @Setter
+    public static class Producer {
+        private String keySerializer;
+        private String valueSerializer;
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/presentation/controller/PaymentController.java
+++ b/payment/src/main/java/com/quit/payment/presentation/controller/PaymentController.java
@@ -34,11 +34,12 @@ public class PaymentController {
         return ResponseEntity.ok(ApiResponse.success(paymentService.createPayment(reservationId, request.toDto())));
     }
 
-    @PostMapping("/{paymentsId}/cancel")
+    @PostMapping("/{paymentsId}/cancel/{reservationId}")
     public ResponseEntity<ApiResponse<PaymentResponse>> cancelPayment(
-            @PathVariable UUID paymentsId,
+            @PathVariable(name = "paymentsId") UUID paymentsId,
+            @PathVariable(name = "reservationId") UUID reservationId,
             @Valid @RequestBody CancelPaymentRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelPayment(paymentsId, request)));
+        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelPayment(paymentsId, reservationId, request)));
     }
 
     @GetMapping("/{reservationId}")

--- a/payment/src/main/java/com/quit/payment/presentation/controller/PaymentController.java
+++ b/payment/src/main/java/com/quit/payment/presentation/controller/PaymentController.java
@@ -27,10 +27,11 @@ public class PaymentController {
         return ResponseEntity.ok(ApiResponse.success(paymentService.createTempPayment(request.toDto())));
     }
 
-    @PostMapping
+    @PostMapping("/{reservationId}")
     public ResponseEntity<ApiResponse<PaymentResponse>> createPayment(
+            @PathVariable UUID reservationId,
             @Valid @RequestBody CreatePaymentRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.createPayment(request.toDto())));
+        return ResponseEntity.ok(ApiResponse.success(paymentService.createPayment(reservationId, request.toDto())));
     }
 
     @PostMapping("/{paymentsId}/cancel")

--- a/payment/src/main/java/com/quit/payment/presentation/controller/PaymentController.java
+++ b/payment/src/main/java/com/quit/payment/presentation/controller/PaymentController.java
@@ -34,12 +34,12 @@ public class PaymentController {
         return ResponseEntity.ok(ApiResponse.success(paymentService.createPayment(reservationId, request.toDto())));
     }
 
-    @PostMapping("/{paymentsId}/cancel/{reservationId}")
+    @PostMapping("/{paymentId}/cancel/{reservationId}")
     public ResponseEntity<ApiResponse<PaymentResponse>> cancelPayment(
-            @PathVariable(name = "paymentsId") UUID paymentsId,
+            @PathVariable(name = "paymentId") UUID paymentId,
             @PathVariable(name = "reservationId") UUID reservationId,
             @Valid @RequestBody CancelPaymentRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelPayment(paymentsId, reservationId, request)));
+        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelPayment(paymentId, reservationId, request)));
     }
 
     @GetMapping("/{reservationId}")

--- a/payment/src/main/java/com/quit/payment/presentation/exception/ErrorType.java
+++ b/payment/src/main/java/com/quit/payment/presentation/exception/ErrorType.java
@@ -16,6 +16,8 @@ public enum ErrorType {
 
     PAYMENT_DATA_INVALID(NOT_FOUND, "해당 결제 데이터가 존재하지 않습니다."),
     PAYMENT_NOT_FOUND(NOT_FOUND, "결제가 존재하지 않습니다."),
+
+    RESERVATION_ID_MISMATCH(BAD_REQUEST, "결제 데이터와 예약 ID가 일치하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/payment/src/main/java/com/quit/payment/presentation/exception/ErrorType.java
+++ b/payment/src/main/java/com/quit/payment/presentation/exception/ErrorType.java
@@ -17,7 +17,9 @@ public enum ErrorType {
     PAYMENT_DATA_INVALID(NOT_FOUND, "해당 결제 데이터가 존재하지 않습니다."),
     PAYMENT_NOT_FOUND(NOT_FOUND, "결제가 존재하지 않습니다."),
 
-    RESERVATION_ID_MISMATCH(BAD_REQUEST, "결제 데이터와 예약 ID가 일치하지 않습니다.")
+    RESERVATION_ID_MISMATCH(BAD_REQUEST, "결제 데이터와 예약 ID가 일치하지 않습니다."),
+
+    KAFKA_MESSAGE_SEND_FAILED(INTERNAL_SERVER_ERROR, "Kafka 메시지 발행에 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -3,7 +3,6 @@ spring:
     name: store
   profiles:
     active: dev
-
   jpa:
     hibernate:
       ddl-auto: update
@@ -12,6 +11,11 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
 server:
   port: 19095


### PR DESCRIPTION
## #️⃣연관된 이슈

close #49 

## 📝작업 내용
- Kafka 설정
- 메세지 발행 로직 추가
- reservation 단 건 조회 openFeign 사용하여 호출
    - OpenFeign 으로 reservation 존재 여부 확인 후 메세지 데이터에 포함 하였습니다.

> 추후 에러처리 관련 로직 추가 예정

### 스크린샷 (선택)
- 메세지 발행 확인
<img width="1311" alt="스크린샷 2025-01-08 오후 7 23 00" src="https://github.com/user-attachments/assets/dd99dd31-564e-4287-8bdf-3735f10c462d" />

<img width="1319" alt="스크린샷 2025-01-08 오후 7 22 44" src="https://github.com/user-attachments/assets/85e58261-ed76-49d5-b713-471c6df08967" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
