### PR TITLE
[feat] 가게 서비스 kafka 적용

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
 	//kafka
 	implementation 'org.springframework.kafka:spring-kafka'
-	testImplementation 'org.springframework.kafka:spring-kafka-test'
+//	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 dependencyManagement {

--- a/payment/src/main/java/com/quit/payment/application/dto/ReservationEvent.java
+++ b/payment/src/main/java/com/quit/payment/application/dto/ReservationEvent.java
@@ -1,0 +1,15 @@
+package com.quit.payment.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@ToString
+public class ReservationEvent {
+    private UUID reservationSlotId;
+    private Integer currentCapacity;
+}

--- a/payment/src/test/java/com/quit/payment/PaymentApplicationTests.java
+++ b/payment/src/test/java/com/quit/payment/PaymentApplicationTests.java
@@ -1,13 +1,43 @@
 package com.quit.payment;
 
+import com.quit.payment.application.dto.ReservationEvent;
+import com.quit.payment.infrastructure.kafka.KafkaProducer;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
 
 @SpringBootTest
 class PaymentApplicationTests {
 
+	@Autowired
+	private KafkaProducer kafkaProducer;
+
 	@Test
-	void contextLoads() {
+	void testSendSuccessMessage() {
+		// 메시지 생성
+		ReservationEvent message = new ReservationEvent();
+		UUID uuid = UUID.fromString("972a1e2c-a2b1-4704-96c7-63cddbddbb41");
+		message.setReservationSlotId(uuid);
+		message.setCurrentCapacity(2);
+
+		// Kafka로 메시지 전송
+		kafkaProducer.sendMessage("reservation.confirm.success", message.getReservationSlotId().toString(), message);
+		System.out.println("Message sent to Kafka: " + message);
+	}
+
+	@Test
+	void testSendFailMessage() {
+		// 메시지 생성
+		ReservationEvent message = new ReservationEvent();
+		UUID uuid = UUID.fromString("972a1e2c-a2b1-4704-96c7-63cddbddbb41");
+		message.setReservationSlotId(uuid);
+		message.setCurrentCapacity(2);
+
+		// Kafka로 메시지 전송
+		kafkaProducer.sendMessage("reservation.confirm.failed", message.getReservationSlotId().toString(), message);
+		System.out.println("Message sent to Kafka: " + message);
 	}
 
 }

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	//kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 dependencyManagement {

--- a/store/src/main/java/com/quit/store/application/dto/ReservationEvent.java
+++ b/store/src/main/java/com/quit/store/application/dto/ReservationEvent.java
@@ -1,0 +1,13 @@
+package com.quit.store.application.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.UUID;
+
+@Getter
+@ToString
+public class ReservationEvent {
+    private UUID reservationSlotId;
+    private Integer currentCapacity;
+}

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -1,5 +1,6 @@
 package com.quit.store.application.service;
 
+import com.quit.store.application.dto.ReservationEvent;
 import com.quit.store.application.dto.ReservationSlotDto;
 import com.quit.store.application.dto.UpdateReservationSlotDto;
 import com.quit.store.application.dto.res.ReservationSlotResponse;
@@ -9,8 +10,10 @@ import com.quit.store.domain.repository.ReservationSlotRepository;
 import com.quit.store.domain.repository.StoreRepository;
 import com.quit.store.presentation.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,7 @@ import java.util.UUID;
 
 import static com.quit.store.presentation.exception.ErrorType.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -28,6 +32,7 @@ public class ReservationSlotService {
     private final ReservationSlotRepository reservationSlotRepository;
     private final StoreRepository storeRepository;
 
+    @Transactional
     public ReservationSlotResponse createSlot(UUID storeId, ReservationSlotDto request, String userId) {
         // todo: 권한체크로직
         Store store = checkStore(storeId);
@@ -36,6 +41,7 @@ public class ReservationSlotService {
         return ReservationSlotResponse.from(slot);
     }
 
+    @Transactional
     public ReservationSlotResponse updateSlot(UUID storeId, UUID slotId,
                                               UpdateReservationSlotDto request, String userId) {
         // todo: 권한체크로직
@@ -66,6 +72,7 @@ public class ReservationSlotService {
         return ReservationSlotResponse.from(slot);
     }
 
+    @Transactional
     public void deleteSlot(UUID storeId, UUID slotId, String userId) {
         // todo: 권한체크로직
         Store store = checkStore(storeId);
@@ -73,6 +80,46 @@ public class ReservationSlotService {
         validateSlotBelongsToStore(store.getId(), slot);
         validateReservation(slot);
         slot.delete(userId);
+    }
+
+    @Transactional
+    @KafkaListener(topics = "reservation.confirm.success", groupId = "reservation-slot", containerFactory = "kafkaReservationEventContainerFactory")
+    public void increaseCapacity(ReservationEvent reservationEvent) {
+        log.info(">>>>>>> increaseCapacity <<<<<<<<<");
+        ReservationSlot reservationSlot = checkSlot(reservationEvent.getReservationSlotId());
+        validateSlotIsAvailable(reservationSlot);
+        validateCapacityLimit(reservationSlot, reservationEvent.getCurrentCapacity());
+        reservationSlot.increaseCapacity(reservationEvent.getCurrentCapacity());
+        log.info("<<<<<<< reservation slot increased <<<<<<<<<");
+    }
+
+    @Transactional
+    @KafkaListener(topics = "reservation.confirm.failed", groupId = "reservation-slot", containerFactory = "kafkaReservationEventContainerFactory")
+    public void restoreCapacity(ReservationEvent reservationEvent) {
+        log.info(">>>>>>> restoreCapacity <<<<<<<<<");
+        ReservationSlot reservationSlot = checkSlot(reservationEvent.getReservationSlotId());
+        validateSlotIsAvailable(reservationSlot);
+        validateSufficientCapacity(reservationSlot, reservationEvent.getCurrentCapacity());
+        reservationSlot.restoreCapacity(reservationEvent.getCurrentCapacity());
+        log.info("<<<<<<< reservation slot restored <<<<<<<<<");
+    }
+
+    private void validateSlotIsAvailable(ReservationSlot slot) {
+        if (!slot.getIsAvailable()) {
+            throw new CustomException(RESERVATION_SLOT_NOT_AVAILABLE);
+        }
+    }
+
+    private void validateCapacityLimit(ReservationSlot slot, int increment) {
+        if ((slot.getCurrentCapacity() + increment) > slot.getMaxCapacity()) {
+            throw new CustomException(RESERVATION_SLOT_MAX_CAPACITY_LIMIT_EXCEEDED);
+        }
+    }
+
+    private void validateSufficientCapacity(ReservationSlot slot, int decrement) {
+        if ((slot.getCurrentCapacity() - decrement) < 0) {
+            throw new CustomException(RESERVATION_SLOT_CURRENT_CAPACITY_INVALID);
+        }
     }
 
     private void validateSlotBelongsToStore(UUID storeId, ReservationSlot slot) {

--- a/store/src/main/java/com/quit/store/domain/entity/ReservationSlot.java
+++ b/store/src/main/java/com/quit/store/domain/entity/ReservationSlot.java
@@ -60,6 +60,14 @@ public class ReservationSlot extends BaseEntity {
                 .build();
     }
 
+    public void increaseCapacity(int increment) {
+        this.currentCapacity += increment;
+    }
+
+    public void restoreCapacity(int decrement) {
+        this.currentCapacity -= decrement;
+    }
+
     public void update(UpdateReservationSlotDto request) {
         updateDate(request.getDate());
         updateTime(request.getTime());

--- a/store/src/main/java/com/quit/store/infrastructure/kafka/KafkaConsumerConfig.java
+++ b/store/src/main/java/com/quit/store/infrastructure/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,42 @@
+package com.quit.store.infrastructure.kafka;
+
+import com.quit.store.application.dto.ReservationEvent;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public ConsumerFactory<String, ReservationEvent> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getKeyDeserializer());
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getValueDeserializer());
+        configProps.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        configProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, ReservationEvent.class.getName());
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ReservationEvent> kafkaReservationEventContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ReservationEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+}

--- a/store/src/main/java/com/quit/store/infrastructure/kafka/KafkaProperties.java
+++ b/store/src/main/java/com/quit/store/infrastructure/kafka/KafkaProperties.java
@@ -1,0 +1,24 @@
+package com.quit.store.infrastructure.kafka;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.kafka")
+public class KafkaProperties {
+
+    private String bootstrapServers;
+    private Consumer consumer = new Consumer();
+
+    @Getter
+    @Setter
+    public static class Consumer {
+        private String keyDeserializer;
+        private String valueDeserializer;
+    }
+
+}

--- a/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
+++ b/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
@@ -28,6 +28,9 @@ public enum ErrorType {
     STORE_CATEGORY_EMPTY(BAD_REQUEST, "가게 카테고리가 존재하지 않습니다."),
 
     RESERVATION_SLOT_NOT_FOUND(NOT_FOUND, "예약 스케줄이 존재하지 않습니다."),
+    RESERVATION_SLOT_NOT_AVAILABLE(BAD_REQUEST, "예약 슬롯이 활성화되어 있지 않습니다."),
+    RESERVATION_SLOT_CURRENT_CAPACITY_INVALID(BAD_REQUEST, "현재 예약 인원이 0보다 작을 수 없습니다."),
+    RESERVATION_SLOT_MAX_CAPACITY_LIMIT_EXCEEDED(BAD_REQUEST, "최대 예약 가능 인원을 초과할 수 없습니다."),
     RESERVATION_SLOT_DATE_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 날짜를 변경할 수 없습니다."),
     RESERVATION_SLOT_TIME_NOT_ALLOWED(BAD_REQUEST, "현재 예약된 인원이 있어 시간을 변경할 수 없습니다."),
     RESERVATION_SLOT_MAX_CAPACITY_NOT_ALLOWED(BAD_REQUEST, "최대 예약 가능 인원이 현재 예약된 인원보다 적을 수 없습니다."),
@@ -37,7 +40,6 @@ public enum ErrorType {
     RESERVATION_SLOT_TIME_EMPTY(BAD_REQUEST, "예약 스케줄 시간이 존재하지 않습니다."),
     RESERVATION_SLOT_MAX_CAPACITY_EMPTY(BAD_REQUEST, "예약스케줄 최대 예약 가능 인원이 존재하지 않습니다."),
     RESERVATION_SLOT_MAX_CAPACITY_INVALID(BAD_REQUEST, "예약스케줄 최대 예약 가능 인원이 유효하지 않습니다."),
-
     ;
 
     private final HttpStatus httpStatus;

--- a/store/src/main/resources/application.yml
+++ b/store/src/main/resources/application.yml
@@ -3,7 +3,6 @@ spring:
     name: store
   profiles:
     active: dev
-
   jpa:
     hibernate:
       ddl-auto: update
@@ -12,6 +11,11 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
 
 server:
   port: 19093


### PR DESCRIPTION
## #️⃣연관된 이슈

close #56 

## 📝작업 내용

- 가게 서비스 kafka 적용 및 비동기 처리
    - 예약 서비스에서 발행하는 메세지 소비하여 현재예약인원 증가와 복구 로직을 비동기로 처리

> 테스트를 위해 결제 서비스에서 구현해놓은 kafka 메세지 발행 로직으로 테스트를 진행하였습니다.
> 예약서비스에서 kafka 적용되면 해당 테스트 삭제 진행할 예정입니다.

### 스크린샷 (선택)

- kafka ui 에서 메세지 소비 확인
<img width="1317" alt="스크린샷 2025-01-09 오후 3 01 58" src="https://github.com/user-attachments/assets/b7449c62-eded-4000-8799-1bfcb372be31" />
<img width="1316" alt="스크린샷 2025-01-09 오후 3 02 07" src="https://github.com/user-attachments/assets/0cc95fe8-c213-4fb8-9d7c-3ef3042c5bda" />
<img width="1315" alt="스크린샷 2025-01-09 오후 3 02 13" src="https://github.com/user-attachments/assets/cb20f5f9-563a-476a-97c0-578028bafc37" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
