### PR TITLE
[fix] Rate Limit 적용 후 조회가 안되는 현상 수정

### DIFF
--- a/gateway-server/src/main/java/com/quit/gateway/infrastructure/config/RateLimitConfig.java
+++ b/gateway-server/src/main/java/com/quit/gateway/infrastructure/config/RateLimitConfig.java
@@ -16,7 +16,7 @@ public class RateLimitConfig {
                 String ipAddress = exchange.getRequest().getRemoteAddress().getAddress().getHostAddress();
                 return Mono.just(ipAddress);
             }
-            return Mono.empty(); // 기본 키 값 설정 (필요한 경우)
+            return Mono.just("default"); // 기본 키 값 설정 (필요한 경우)
         };
     }
 }

--- a/gateway-server/src/main/resources/application.yml
+++ b/gateway-server/src/main/resources/application.yml
@@ -19,8 +19,6 @@ spring:
           predicates:
             - Path=/api/users/**, /api/auth/**
           filters:
-            - RemoveRequestHeader=Cookie
-            - PreserveHostHeader
             - name: RequestRateLimiter
               args:
                   redis-rate-limiter.replenishRate: 1

--- a/user-server/src/main/java/com/quit/user/application/service/UserService.java
+++ b/user-server/src/main/java/com/quit/user/application/service/UserService.java
@@ -18,7 +18,7 @@ public class UserService {
 
     //사용자 전체 조회
     public List<UserDto> getUserList(String role){
-        if (role.equals(UserRoleEnum.MASTER.toString())) {
+        if ( UserRoleEnum.fromRole(role) == UserRoleEnum.MASTER) {
             List<User> users = userRepository.findAll();
             List<UserDto> userDtos = new ArrayList<>();
             for (User user : users) {


### PR DESCRIPTION
- gw yml에서 사용하지 않는 filter 삭제

#

> ex) #이슈번호, #이슈번호
GW 의 RateLimitConfig 에 login이 아닌 다른 url접근 시 
`return Mono.empty();`
로 처리가 잘못되어있었습니다.
현재 return Mono.just("default"); // 기본 키 값 설정
기본값을 설정해두었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

