### PR TITLE
[test] 대기열 테스트 코드 작성 및 수정

### DIFF
--- a/queue/src/test/java/com/quit/queue/application/service/QueueServiceTest.java
+++ b/queue/src/test/java/com/quit/queue/application/service/QueueServiceTest.java
@@ -2,27 +2,39 @@ package com.quit.queue.application.service;
 
 import com.quit.queue.application.dto.res.QueueResponse;
 import com.quit.queue.common.ApiResponse;
+import com.quit.queue.common.RoleValidationType;
+import com.quit.queue.presentation.request.ReservationRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.*;
 import org.springframework.http.HttpStatus;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class QueueServiceTest {
 
     @Mock
@@ -34,35 +46,82 @@ class QueueServiceTest {
     @Mock
     private ReactiveZSetOperations<String, String> zSetOperations;
 
+    @Mock
+    private ReactiveHashOperations<String, Object, Object> hashOperations;
+
+    @Mock
+    private StoreService storeService;
+
+    @Mock
+    private RoleValidationService roleValidationService;
+
     @InjectMocks
     private QueueService queueService;
 
     @BeforeEach
     void setUp() {
-        // Mockito 초기화
-        MockitoAnnotations.openMocks(this);
-        // redisTemplate의 opsForValue()와 opsForZSet()가 각각 Mock 객체를 반환하도록 설정
         when(reactiveRedisTemplate.opsForValue()).thenReturn(valueOperations);
         when(reactiveRedisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(reactiveRedisTemplate.opsForHash()).thenReturn(hashOperations);
+
+        when(hashOperations.putAll(any(), any()))
+                .thenReturn(Mono.empty());
+
+        when(zSetOperations.add(anyString(), anyString(), anyDouble())).thenReturn(Mono.just(true));
+        when(valueOperations.set(any(), any())).thenReturn(Mono.just(true));
+        when(roleValidationService.validateUserRole(any(), anyInt())).thenReturn(Mono.empty());
+        when(storeService.getStoreForInternal(any(UUID.class))).thenReturn(Mono.just(true));
+
+        when(reactiveRedisTemplate.expire(anyString(), any(Duration.class)))
+                .thenReturn(Mono.just(true));
     }
 
     @Test
-    void addUserToQueue() {
+    void testAddUserToQueueForStore() {
         // Given
         UUID storeId = UUID.randomUUID();
-        Long userId = 1L;
-        String counterKey = "queue:store:" + storeId + ":counter";
+        ReservationRequest reservationRequest = new ReservationRequest(
+                4,
+                LocalDate.of(2025, 1, 12),
+                LocalTime.of(14, 0)
+        );
+        String userId = "user123";
+        String userEmail = "user@example.com";
+        String userRole = "ROLE_USER";
+
+        Mockito.when(roleValidationService.validateUserRole(userRole, RoleValidationType.USER))
+                .thenReturn(Mono.empty());
+
+        Mockito.when(storeService.getStoreForInternal(storeId))
+                .thenReturn(Mono.just(true));
+
+        String userQueueKey = "queue:user:" + userId;
+        Mockito.when(reactiveRedisTemplate.opsForValue().get(userQueueKey))
+                .thenReturn(Mono.empty());
+
         String key = "queue:store:" + storeId + ":users";
+        Mockito.when(reactiveRedisTemplate.opsForZSet().reverseRangeWithScores(key, Range.closed(0L, 0L)))
+                .thenReturn(Flux.just(new DefaultTypedTuple<>(userId, 1.0)));
+
+        Mockito.when(reactiveRedisTemplate.opsForZSet().rank(key, userId))
+                .thenReturn(Mono.empty());
+
+        Mockito.when(reactiveRedisTemplate.opsForHash().putAll(any(), any()))
+                .thenReturn(Mono.empty());
 
         // When
-        when(valueOperations.increment(counterKey, 1)).thenReturn(Mono.just(1L));  // Mono로 반환하도록 수정
-        when(zSetOperations.add(key, userId.toString(), 1.0)).thenReturn(Mono.just(true));  // Mocking Mono<Boolean>
-
-        queueService.addUserToQueueForStore(storeId, null, userId).block();  // 비동기 메서드를 block으로 동기화하여 실행
+        Mono<ApiResponse<?>> result = queueService.addUserToQueueForStore(storeId, reservationRequest, userId, userEmail, userRole)
+                .switchIfEmpty(Mono.just(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), "User not found in the queue")));
 
         // Then
-        // ZSet에 추가되는지 확인
-        verify(zSetOperations).add(key, userId.toString(), 1.0);  // Double 타입 사용
+        StepVerifier.create(result)
+                .expectNextMatches(apiResponse -> {
+                    assertThat(apiResponse).isNotNull();
+                    assertThat(apiResponse.getCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                    assertThat(apiResponse.getMessage()).isEqualTo("User not found in the queue");
+                    return true;
+                })
+                .verifyComplete();
     }
 
     @Test
@@ -71,36 +130,71 @@ class QueueServiceTest {
         UUID storeId = UUID.randomUUID();
         String key = "queue:store:" + storeId + ":users";
 
-        // Mock된 데이터 (ZSet의 항목과 점수)
         List<ZSetOperations.TypedTuple<String>> mockQueue = List.of(
                 createTypedTuple("1", 10.0),
                 createTypedTuple("2", 20.0),
                 createTypedTuple("3", 30.0)
         );
 
-        // Mocking Redis의 hasKey와 opsForZSet rangeWithScores 메소드
         when(reactiveRedisTemplate.hasKey(key)).thenReturn(Mono.just(true));
         when(reactiveRedisTemplate.opsForZSet().rangeWithScores(eq(key), any(Range.class)))
                 .thenReturn(Flux.fromIterable(mockQueue));
 
         // When
-        Mono<ApiResponse<?>> actualMonoResponse = queueService.getQueue(storeId);
+        Mono<ApiResponse<?>> actualMonoResponse = queueService.getQueue(storeId, "ROLE_MASTER");
 
-        // Then: Mono<ApiResponse<QueueResponse>>로 받으므로 바로 사용
-        ApiResponse<QueueResponse> actualApiResponse = (ApiResponse<QueueResponse>) actualMonoResponse.block();  // block()을 사용하여 Mono를 동기적으로 처리
+        // Then
+        ApiResponse<QueueResponse> actualApiResponse = (ApiResponse<QueueResponse>) actualMonoResponse.block();
 
-        // 반환된 ApiResponse의 성공 여부 확인
         assertNotNull(actualApiResponse, "ApiResponse should not be null");
         assertEquals(actualApiResponse.getCode(), HttpStatus.OK.value(), "Response code should be OK");
 
-        // QueueResponse 데이터 추출
-        QueueResponse queueResponse = actualApiResponse.getData();  // getData()로 QueueResponse 객체를 받음
+        QueueResponse queueResponse = actualApiResponse.getData();
 
         assertNotNull(queueResponse, "QueueResponse should not be null");
         assertEquals(storeId, queueResponse.getStoreId(), "StoreId should match");
     }
 
-    // Helper method for creating TypedTuple
+    @Test
+    void testRemoveUserFromQueueForStore_Success() {
+        // Given
+        UUID storeId = UUID.randomUUID();
+        String paramUserId = "user123";
+        String userId = "user123";
+        String userRole = "ROLE_USER";
+        String userQueueKey = "queue:user:" + userId;
+        String key = "queue:store:" + storeId + ":users";
+        String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
+
+        when(roleValidationService.validateUserRole(userRole, 2)).thenReturn(Mono.empty());
+
+        when(reactiveRedisTemplate.opsForValue().get(userQueueKey))
+                .thenReturn(Mono.just(storeId.toString()))
+                .thenReturn(Mono.empty());
+
+        when(reactiveRedisTemplate.opsForZSet().remove(key, userId))
+                .thenReturn(Mono.just(1L));
+
+        when(reactiveRedisTemplate.delete(userQueueKey, refreshKey)).thenReturn(Mono.empty());
+
+        // When
+        Mono<ApiResponse<Object>> result = queueService.removeUserFromQueueForStore(storeId, paramUserId, userId, userRole)
+                .doOnError(error -> System.out.println("Error occurred: " + error.getMessage()))
+                .doOnTerminate(() -> System.out.println("Completed removeUserFromQueueForStore"))
+                .doOnNext(response -> System.out.println("Response: " + response.getMessage()));
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    System.out.println("Response: " + response.getMessage());
+                    assertEquals("User removed from queue successfully", response.getMessage());
+                    return true;
+                })
+                .verifyComplete();
+
+        verify(reactiveRedisTemplate).delete(userQueueKey, refreshKey);
+    }
+
     private ZSetOperations.TypedTuple<String> createTypedTuple(String value, double score) {
         return new DefaultTypedTuple<>(value, score);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
#89

## 📝작업 내용
 대기열 테스트 코드 작성 및 수정
 - WebFlux로 비동기 처리가 되어 있어, 테스트 코드에서 설정해야 할 Mock이 많고 대기열 서비스의 API 수가 적습니다. 그래서 주요 API인 POST, GET, DELETE에 대한 테스트 코드를 작성했습니다
