### PR TITLE
[feat] 일정 기간의 예약 스케줄 생성 기능 구현

### DIFF
--- a/store/src/main/java/com/quit/store/application/dto/BatchReservationSlotsDto.java
+++ b/store/src/main/java/com/quit/store/application/dto/BatchReservationSlotsDto.java
@@ -1,0 +1,47 @@
+package com.quit.store.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BatchReservationSlotsDto {
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private Integer interval;
+    private Integer maxCapacity;
+
+    @Builder
+    private BatchReservationSlotsDto(LocalDate startDate, LocalDate endDate,
+                                    LocalTime startTime, LocalTime endTime,
+                                    Integer interval, Integer maxCapacity) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.interval = interval;
+        this.maxCapacity = maxCapacity;
+    }
+
+    public static BatchReservationSlotsDto of(LocalDate startDate, LocalDate endDate,
+                                              LocalTime startTime, LocalTime endTime,
+                                              Integer interval, Integer maxCapacity) {
+        return BatchReservationSlotsDto.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .interval(interval)
+                .maxCapacity(maxCapacity)
+                .build();
+    }
+
+}

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -55,36 +55,10 @@ public class ReservationSlotService {
         roleValidator.validateRole(userRole, CREATE);
         Store store = checkStore(storeId);
         checkUser(store, userId, userRole);
-
-        LocalDate startDate = request.getStartDate();
-        LocalDate endDate = request.getEndDate();
-        int interval = request.getInterval();
-
         // 기존 슬롯을 조회하여 중복을 방지
-        List<ReservationSlot> existingSlots = reservationSlotRepository.findAllByStoreIdAndDateRange(storeId, startDate, endDate);
-
-        Set<String> existingSlotKeys = existingSlots.stream()
-                .map(slot -> slot.getDate().toString() + "_" + slot.getTime().toString())
-                .collect(Collectors.toSet());
-
-        List<ReservationSlot> newSlots = new ArrayList<>();
-
-        // 예약 슬롯 생성 로직
-        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-            for (LocalTime time = request.getStartTime(); !time.isAfter(request.getEndTime()); time = time.plusMinutes(interval)) {
-                String key = date.toString() + "_" + time.toString();
-                if (!existingSlotKeys.contains(key)) {
-                    ReservationSlot slot = ReservationSlot.of(
-                            date,
-                            time,
-                            request.getMaxCapacity(),
-                            store
-                    );
-                    newSlots.add(slot);
-                }
-            }
-        }
-
+        List<ReservationSlot> existingSlots = findExistingSlots(storeId, request.getStartDate(), request.getEndDate());
+        Set<String> existingSlotKeys = generateSlotKeys(existingSlots);
+        List<ReservationSlot> newSlots = generateBatchSlots(request, existingSlotKeys, store);
         reservationSlotRepository.saveAll(newSlots);
     }
 
@@ -150,6 +124,29 @@ public class ReservationSlotService {
         validateSufficientCapacity(reservationSlot, reservationEvent.getCurrentCapacity());
         reservationSlot.restoreCapacity(reservationEvent.getCurrentCapacity());
         log.info("<<<<<<< reservation slot restored <<<<<<<<<");
+    }
+
+    private Set<String> generateSlotKeys(List<ReservationSlot> existingSlots) {
+        return existingSlots.stream()
+                .map(slot -> slot.getDate().toString() + "_" + slot.getTime().toString())
+                .collect(Collectors.toSet());
+    }
+
+    private List<ReservationSlot> findExistingSlots(UUID storeId, LocalDate startDate, LocalDate endDate) {
+        return reservationSlotRepository.findAllByStoreIdAndDateRange(storeId, startDate, endDate);
+    }
+
+    private List<ReservationSlot> generateBatchSlots(BatchReservationSlotsDto request, Set<String> existingSlotKeys, Store store) {
+        List<ReservationSlot> newSlots = new ArrayList<>();
+        for (LocalDate date = request.getStartDate(); !date.isAfter(request.getEndDate()); date = date.plusDays(1)) {
+            for (LocalTime time = request.getStartTime(); !time.isAfter(request.getEndTime()); time = time.plusMinutes(request.getInterval())) {
+                String key = date + "_" + time;
+                if (!existingSlotKeys.contains(key)) {
+                    newSlots.add(ReservationSlot.of(date, time, request.getMaxCapacity(), store));
+                }
+            }
+        }
+        return newSlots;
     }
 
     private void validateSlotIsAvailable(ReservationSlot slot) {

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -1,5 +1,6 @@
 package com.quit.store.application.service;
 
+import com.quit.store.application.dto.BatchReservationSlotsDto;
 import com.quit.store.application.dto.ReservationEvent;
 import com.quit.store.application.dto.ReservationSlotDto;
 import com.quit.store.application.dto.UpdateReservationSlotDto;
@@ -20,7 +21,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.quit.store.common.util.RoleValidator.Action.*;
 import static com.quit.store.presentation.exception.ErrorType.*;
@@ -36,13 +41,51 @@ public class ReservationSlotService {
     private final RoleValidator roleValidator;
 
     @Transactional
-    public ReservationSlotResponse createSlot(UUID storeId, ReservationSlotDto request, String userId, String userRole) {
+    public ReservationSlotResponse createSingleSlot(UUID storeId, ReservationSlotDto request, String userId, String userRole) {
         roleValidator.validateRole(userRole, CREATE);
         Store store = checkStore(storeId);
         checkUser(store, userId, userRole);
         ReservationSlot slot = create(store, request);
         reservationSlotRepository.save(slot);
         return ReservationSlotResponse.from(slot);
+    }
+
+    @Transactional
+    public void createBatchSlots(UUID storeId, BatchReservationSlotsDto request, String userId, String userRole) {
+        roleValidator.validateRole(userRole, CREATE);
+        Store store = checkStore(storeId);
+        checkUser(store, userId, userRole);
+
+        LocalDate startDate = request.getStartDate();
+        LocalDate endDate = request.getEndDate();
+        int interval = request.getInterval();
+
+        // 기존 슬롯을 조회하여 중복을 방지
+        List<ReservationSlot> existingSlots = reservationSlotRepository.findAllByStoreIdAndDateRange(storeId, startDate, endDate);
+
+        Set<String> existingSlotKeys = existingSlots.stream()
+                .map(slot -> slot.getDate().toString() + "_" + slot.getTime().toString())
+                .collect(Collectors.toSet());
+
+        List<ReservationSlot> newSlots = new ArrayList<>();
+
+        // 예약 슬롯 생성 로직
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            for (LocalTime time = request.getStartTime(); !time.isAfter(request.getEndTime()); time = time.plusMinutes(interval)) {
+                String key = date.toString() + "_" + time.toString();
+                if (!existingSlotKeys.contains(key)) {
+                    ReservationSlot slot = ReservationSlot.of(
+                            date,
+                            time,
+                            request.getMaxCapacity(),
+                            store
+                    );
+                    newSlots.add(slot);
+                }
+            }
+        }
+
+        reservationSlotRepository.saveAll(newSlots);
     }
 
     @Transactional

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryCustom.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryCustom.java
@@ -6,10 +6,12 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ReservationSlotRepositoryCustom {
     Page<ReservationSlot> findByStoreId(UUID storeId, Pageable pageable);
     Optional<ReservationSlot> findByDateAndTime(UUID storeId, LocalDate date, LocalTime time);
+    List<ReservationSlot> findAllByStoreIdAndDateRange(UUID storeId, LocalDate startDate, LocalDate endDate);
 }

--- a/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryImpl.java
+++ b/store/src/main/java/com/quit/store/domain/repository/ReservationSlotRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.quit.store.domain.repository;
 
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.quit.store.domain.entity.QReservationSlot;
 import com.quit.store.domain.entity.ReservationSlot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,6 +66,22 @@ public class ReservationSlotRepositoryImpl implements ReservationSlotRepositoryC
                 )
                 .fetchOne();
         return Optional.ofNullable(slot);
+    }
+
+    @Override
+    public List<ReservationSlot> findAllByStoreIdAndDateRange(UUID storeId, LocalDate startDate, LocalDate endDate) {
+        return jpaQueryFactory
+                .selectFrom(reservationSlot)
+                .where(
+                        storeEq(storeId),
+                        dateBetween(startDate, endDate),
+                        reservationSlot.isDeleted.eq(false)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression dateBetween(LocalDate startDate, LocalDate endDate) {
+        return startDate != null && endDate != null ? reservationSlot.date.between(startDate, endDate) : null;
     }
 
     private BooleanExpression timeEq(LocalTime time) {

--- a/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
@@ -4,10 +4,10 @@ import com.quit.store.application.dto.res.ReservationSlotResponse;
 import com.quit.store.application.service.ReservationSlotService;
 import com.quit.store.common.dto.ApiResponse;
 import com.quit.store.common.util.PageableUtil;
+import com.quit.store.presentation.dto.BatchReservationSlotsRequest;
 import com.quit.store.presentation.dto.CreateReservationSlotRequest;
 import com.quit.store.presentation.dto.UpdateReservationSlotRequest;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,12 +26,22 @@ public class ReservationSlotController {
     private final ReservationSlotService reservationSlotService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<ReservationSlotResponse>> createSlot(
+    public ResponseEntity<ApiResponse<ReservationSlotResponse>> createSingleSlot(
             @RequestHeader(name = "X-User-Email") String userId,
             @RequestHeader(name = "X-User-Role") String userRole,
             @PathVariable(name = "storeId") UUID storeId,
             @Valid @RequestBody CreateReservationSlotRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(reservationSlotService.createSlot(storeId, request.toDto(), userId, userRole)));
+        return ResponseEntity.ok(ApiResponse.success(reservationSlotService.createSingleSlot(storeId, request.toDto(), userId, userRole)));
+    }
+
+    @PostMapping("/batch")
+    public ResponseEntity<ApiResponse<String>> createBatchSlots(
+            @RequestHeader(name = "X-User-Email") String userId,
+            @RequestHeader(name = "X-User-Role") String userRole,
+            @PathVariable(name = "storeId") UUID storeId,
+            @Valid @RequestBody BatchReservationSlotsRequest request) {
+        reservationSlotService.createBatchSlots(storeId, request.toDto(), userId, userRole);
+        return ResponseEntity.ok(ApiResponse.success("생성을 완료하였습니다."));
     }
 
     @PutMapping("/{slotId}")

--- a/store/src/main/java/com/quit/store/presentation/dto/BatchReservationSlotsRequest.java
+++ b/store/src/main/java/com/quit/store/presentation/dto/BatchReservationSlotsRequest.java
@@ -1,0 +1,49 @@
+package com.quit.store.presentation.dto;
+
+import com.quit.store.application.dto.BatchReservationSlotsDto;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchReservationSlotsRequest {
+
+    @NotNull(message = "RESERVATION_SLOT_START_DATE_EMPTY")
+    private LocalDate startDate;
+
+    @NotNull(message = "RESERVATION_SLOT_END_DATE_EMPTY")
+    private LocalDate endDate;
+
+    @NotNull(message = "RESERVATION_SLOT_START_TIME_EMPTY")
+    private LocalTime startTime;
+
+    @NotNull(message = "RESERVATION_SLOT_END_TIME_EMPTY")
+    private LocalTime endTime;
+
+    @NotNull(message = "RESERVATION_SLOT_INTERVAL_EMPTY")
+    @Positive(message = "RESERVATION_SLOT_INTERVAL_INVALID")
+    private Integer interval;
+
+    @NotNull(message = "RESERVATION_SLOT_MAX_CAPACITY_EMPTY")
+    @Positive(message = "RESERVATION_SLOT_MAX_CAPACITY_INVALID")
+    private Integer maxCapacity;
+
+    public BatchReservationSlotsDto toDto() {
+        return BatchReservationSlotsDto.of(
+                this.startDate,
+                this.endDate,
+                this.startTime,
+                this.endTime,
+                this.interval,
+                this.maxCapacity
+        );
+    }
+
+}

--- a/store/src/main/java/com/quit/store/presentation/dto/UpdateReservationSlotRequest.java
+++ b/store/src/main/java/com/quit/store/presentation/dto/UpdateReservationSlotRequest.java
@@ -1,6 +1,5 @@
 package com.quit.store.presentation.dto;
 
-import com.quit.store.application.dto.ReservationSlotDto;
 import com.quit.store.application.dto.UpdateReservationSlotDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
+++ b/store/src/main/java/com/quit/store/presentation/exception/ErrorType.java
@@ -41,8 +41,16 @@ public enum ErrorType {
     RESERVATION_SLOT_TIME_EMPTY(BAD_REQUEST, "예약 스케줄 시간이 존재하지 않습니다."),
     RESERVATION_SLOT_MAX_CAPACITY_EMPTY(BAD_REQUEST, "예약스케줄 최대 예약 가능 인원이 존재하지 않습니다."),
     RESERVATION_SLOT_MAX_CAPACITY_INVALID(BAD_REQUEST, "예약스케줄 최대 예약 가능 인원이 유효하지 않습니다."),
+    RESERVATION_SLOT_START_DATE_EMPTY(BAD_REQUEST, "예약 스케줄 시작 날짜가 존재하지 않습니다."),
+    RESERVATION_SLOT_END_DATE_EMPTY(BAD_REQUEST, "예약 스케줄 종료 날짜가 존재하지 않습니다."),
+    RESERVATION_SLOT_START_TIME_EMPTY(BAD_REQUEST, "예약 스케줄 시작 시간이 존재하지 않습니다."),
+    RESERVATION_SLOT_END_TIME_EMPTY(BAD_REQUEST, "예약 스케줄 종료 시간이 존재하지 않습니다."),
+    RESERVATION_SLOT_INTERVAL_EMPTY(BAD_REQUEST, "예약 스케줄 간격이 존재하지 않습니다."),
+    RESERVATION_SLOT_INTERVAL_INVALID(BAD_REQUEST, "예약 스케줄 간격이 유효하지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;
     private final String message;
+
 }

--- a/store/src/test/java/com/quit/store/ReservationSlotServiceTest.java
+++ b/store/src/test/java/com/quit/store/ReservationSlotServiceTest.java
@@ -1,5 +1,6 @@
 package com.quit.store;
 
+import com.quit.store.application.dto.BatchReservationSlotsDto;
 import com.quit.store.application.dto.ReservationSlotDto;
 import com.quit.store.application.dto.UpdateReservationSlotDto;
 import com.quit.store.application.dto.res.ReservationSlotResponse;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 
 import static com.quit.store.presentation.exception.ErrorType.*;
@@ -69,12 +71,12 @@ class ReservationSlotServiceTest {
 
     @Test
     @DisplayName("예약 슬롯을 생성할 수 있다.")
-    void createSlot() {
+    void createSingleSlot() {
         // given
         ReservationSlotDto requestDto = ReservationSlotDto.of(date, time, maxCapacity);
 
         // when
-        ReservationSlotResponse response = reservationSlotService.createSlot(storeId, requestDto, userId, userRole);
+        ReservationSlotResponse response = reservationSlotService.createSingleSlot(storeId, requestDto, userId, userRole);
 
         // then
         ReservationSlot actualSlot = findSlotById(response.getSlotId());
@@ -86,15 +88,96 @@ class ReservationSlotServiceTest {
 
     @Test
     @DisplayName("권한이 없는 사용자가 슬롯을 생성하려고 하면 예외가 발생한다.")
-    void createSlotUnauthorized() {
+    void createSingleSlotUnauthorized() {
         // given
         String invalidRole = "ROLE_USER";
         ReservationSlotDto requestDto = ReservationSlotDto.of(date, time, maxCapacity);
 
         // when & then
-        assertThatThrownBy(() -> reservationSlotService.createSlot(storeId, requestDto, userId, invalidRole))
+        assertThatThrownBy(() -> reservationSlotService.createSingleSlot(storeId, requestDto, userId, invalidRole))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(USER_NOT_AUTHORIZED.getMessage());
+    }
+
+    @Test
+    @DisplayName("예약 슬롯 배치를 생성할 수 있다.")
+    void createBatchSlots() {
+        // given
+        BatchReservationSlotsDto requestDto = BatchReservationSlotsDto.of(
+                LocalDate.of(2025, 1, 15),
+                LocalDate.of(2025, 1, 15),
+                LocalTime.of(10, 0),
+                LocalTime.of(18, 0),
+                30,
+                10
+        );
+
+        // when
+        reservationSlotService.createBatchSlots(storeId, requestDto, userId, userRole);
+
+        // then
+        List<ReservationSlot> slots = reservationSlotRepository.findAllByStoreIdAndDateRange(
+                storeId,
+                requestDto.getStartDate(),
+                requestDto.getEndDate()
+        );
+        assertThat(slots).isNotNull();
+        assertThat(slots).hasSize(17);
+        assertThat(slots.get(0).getMaxCapacity()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("권한이 없는 사용자가 슬롯 배치를 생성하려고 하면 예외가 발생한다.")
+    void createBatchSlotsUnauthorized() {
+        // given
+        String invalidRole = "ROLE_USER";
+        BatchReservationSlotsDto requestDto = BatchReservationSlotsDto.of(
+                LocalDate.of(2025, 1, 15),
+                LocalDate.of(2025, 1, 15),
+                LocalTime.of(10, 0),
+                LocalTime.of(18, 0),
+                30,
+                10
+        );
+
+        // when & then
+        assertThatThrownBy(() -> reservationSlotService.createBatchSlots(storeId, requestDto, userId, invalidRole))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(USER_NOT_AUTHORIZED.getMessage());
+    }
+
+    @Test
+    @DisplayName("중복된 예약 슬롯은 생성되지 않는다.")
+    void createBatchSlotsAvoidDuplicate() {
+        // given
+        LocalDate startDate = LocalDate.of(2025, 1, 15);
+        LocalDate endDate = LocalDate.of(2025, 1, 15);
+        LocalTime startTime = LocalTime.of(10, 0);
+        LocalTime endTime = LocalTime.of(18, 0);
+        int interval = 30;
+        int maxCapacity = 10;
+
+        ReservationSlot existingSlot = ReservationSlot.of(
+                startDate,
+                LocalTime.of(10, 30),
+                maxCapacity,
+                storeRepository.findById(storeId).orElseThrow()
+        );
+        reservationSlotRepository.save(existingSlot);
+
+        BatchReservationSlotsDto requestDto = BatchReservationSlotsDto.of(
+                startDate, endDate, startTime, endTime, interval, maxCapacity
+        );
+
+        // when
+        reservationSlotService.createBatchSlots(storeId, requestDto, userId, userRole);
+
+        // then
+        List<ReservationSlot> slots = reservationSlotRepository.findAllByStoreIdAndDateRange(storeId, startDate, endDate);
+
+        assertThat(slots).isNotNull();
+        assertThat(slots).hasSize(17);
+
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #94 

## 📝작업 내용

- 일정 기간에 따른 예약 스케줄의 시작 및 마감시간 받아 여러 건의 예약 스케줄을 생성하는 기능을 구현하였습니다.
    - 요청 받는 값: 시작 기간, 마감 기간, 시작 시간, 마감 시간, 예약 시간의 간격(예: 30분), 최대 예약 인원
    - 요청 값 범위에 해당하는 스케줄을 먼저 조회하여, 중복 스케줄은 제외하고 생성하도록 하였습니다.

> 현재는 동기 형식으로 구현했으나, 추후 비동기 형식으로 전환하여 생성 시간 동안의 DB 부하를 줄이는 방향을 생각하고 있습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
