### PR TITLE
[feat] 내부용 가게 존재 여부 조회 api 캐싱 적용

### DIFF
--- a/store/build.gradle
+++ b/store/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	//kafka
 	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/store/src/main/java/com/quit/store/application/service/StoreService.java
+++ b/store/src/main/java/com/quit/store/application/service/StoreService.java
@@ -9,6 +9,8 @@ import com.quit.store.domain.entity.Store;
 import com.quit.store.domain.repository.StoreRepository;
 import com.quit.store.presentation.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -55,6 +57,7 @@ public class StoreService {
         return storePage.map(StoreResponse::from);
     }
 
+    @CacheEvict(cacheNames = "store", key = "args[0]")
     public void deleteStore(UUID storeId, String userId, String userRole) {
         roleValidator.validateRole(userRole, STORE_DELETE);
         Store store = checkStore(storeId);
@@ -62,6 +65,7 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "store", key = "args[0]")
     public Boolean getStoreForInternal(UUID storeId) {
         return storeRepository.existsByIdAndIsDeletedFalse(storeId);
     }

--- a/store/src/main/java/com/quit/store/infrastructure/configuration/CacheConfig.java
+++ b/store/src/main/java/com/quit/store/infrastructure/configuration/CacheConfig.java
@@ -1,0 +1,41 @@
+package com.quit.store.infrastructure.configuration;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisCacheConfiguration configuration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofHours(1))
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+                );
+
+        return RedisCacheManager
+                .builder(redisConnectionFactory)
+                .cacheDefaults(configuration)
+                .build();
+    }
+
+}

--- a/store/src/main/resources/application.yml
+++ b/store/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}
 
 server:
   port: 19093


### PR DESCRIPTION
## #️⃣연관된 이슈

#98 

## 📝작업 내용

- 대기열에서 요청하는 가게 존재 여부 조회에 캐싱 적용하였습니다. 
    - cache-aside 방식
    - TTL 1시간 적용
    - 가게 삭제 시 redis 에도 삭제될 수 있게 cacheEvict 처리
    - **처리량** 
        - 캐싱 미적용: 4,679.5 req/sec, 캐싱 적용: 9,191.2 req/sec
        - 처리량 약 **96.5% 증가**
    - **평균 응답 시간**
        -  캐싱 미적용: 10ms, 캐싱 적용: 4ms
        -  평균 응답 시간 약 **60% 감소**

### 스크린샷 (선택)
- jmeter 테스트 (스레드수: 50, Loop Count: 20, Ramp-Up Period: 0초, 총 요청 수: 10,000건)
<img width="1099" alt="스크린샷 2025-01-23 오전 2 22 52" src="https://github.com/user-attachments/assets/f68efd9f-982f-47c7-af80-7239b4ea2256" />
<img width="1103" alt="스크린샷 2025-01-23 오전 2 21 01" src="https://github.com/user-attachments/assets/ec042291-04af-41b0-9cd9-2af13694e509" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
