### PR TITLE
[feat] 대기열 멀티 인스턴스 적용 및 과부하 해결

### DIFF
--- a/queue/src/main/java/com/quit/queue/application/scheduler/QueueScheduler.java
+++ b/queue/src/main/java/com/quit/queue/application/scheduler/QueueScheduler.java
@@ -2,8 +2,8 @@ package com.quit.queue.application.scheduler;
 
 import com.quit.queue.application.messaging.ReservationMessage;
 import com.quit.queue.infrastructure.messaging.KafkaMessageProducer;
+import com.quit.queue.infrastructure.util.ServerInfo;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -11,33 +11,35 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class QueueScheduler {
+    private final ServerInfo serverInfo;
+
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
     private final KafkaMessageProducer kafkaMessageProducer;
 
-    @Scheduled(fixedRate = 5000)
+    @Scheduled(fixedRate = 10000)
     public void processQueues() {
-        Flux<String> queueKeys = reactiveRedisTemplate.keys("queue:store:*:users");
+        String serverId = serverInfo.getServerId();
+        String storesKey = "queue:server:" + serverId + ":stores";
 
-        queueKeys.parallel()
-                .runOn(Schedulers.parallel())
-                .flatMap(this::processQueue)
-                .sequential()
+        reactiveRedisTemplate.opsForSet().members(storesKey)
+                .flatMap(storeId -> {
+                    String queueKey = "queue:store:" + storeId + ":users";
+                    return processQueue(queueKey);
+                })
                 .subscribe();
     }
 
     private Mono<Void> processQueue(String queueKey) {
-        UUID storeId = UUID.fromString(queueKey.split(":")[2]);
+        String storeId = queueKey.split(":")[2];
 
         return reactiveRedisTemplate.opsForZSet().rangeWithScores(queueKey, Range.closed(0L, 499L))
                 .collectList()
@@ -65,7 +67,7 @@ public class QueueScheduler {
                                                         }
 
                                                         ReservationMessage reservationMessage = ReservationMessage.of(
-                                                                userId, (String) values.get(0), storeId.toString(), (String) values.get(1), (String) values.get(2), (String) values.get(3));
+                                                                userId, (String) values.get(0), storeId, (String) values.get(1), (String) values.get(2), (String) values.get(3));
                                                         return sendToReservationService(reservationMessage);
                                                     });
                                         });

--- a/queue/src/main/java/com/quit/queue/application/service/QueueService.java
+++ b/queue/src/main/java/com/quit/queue/application/service/QueueService.java
@@ -25,9 +25,10 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class QueueService {
+    private final StoreService storeService;
+
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
     private final RoleValidationService roleValidationService;
-    private final StoreService storeService;
 
     public Mono<ApiResponse<?>> addUserToQueueForStore(UUID storeId, ReservationRequest reservationRequest, String userId, String userEmail, String userRole) {
         return roleValidationService.validateUserRole(userRole, RoleValidationType.USER)

--- a/queue/src/main/java/com/quit/queue/application/service/RoleValidationService.java
+++ b/queue/src/main/java/com/quit/queue/application/service/RoleValidationService.java
@@ -26,6 +26,11 @@ public class RoleValidationService {
                         return Mono.error(new UnauthorizedException("Unauthorized role: " + userRole));
                     }
                     break;
+                case RoleValidationType.NOT_USER:
+                    if (!(userRole.equals("ROLE_OWNER") || userRole.equals("ROLE_MASTER") || userRole.equals("ROLE_MANAGER"))) {
+                        return Mono.error(new UnauthorizedException("Unauthorized role: " + userRole));
+                    }
+                    break;
                 default:
                     return Mono.error(new IllegalArgumentException("Invalid validation type: " + validationType));
             }

--- a/queue/src/main/java/com/quit/queue/application/service/StoreServerAssignmentService.java
+++ b/queue/src/main/java/com/quit/queue/application/service/StoreServerAssignmentService.java
@@ -1,0 +1,37 @@
+package com.quit.queue.application.service;
+
+import com.quit.queue.common.RoleValidationType;
+import com.quit.queue.infrastructure.util.ServerInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StoreServerAssignmentService {
+    private final RoleValidationService roleValidationService;
+    private final ServerInfo serverInfo;
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    public Mono<Void> assignStoreToServer(UUID storeId, String userRole) {
+        String serverId = serverInfo.getServerId();
+        String key = "queue:server:" + serverId + ":stores";
+
+        return roleValidationService.validateUserRole(userRole, RoleValidationType.NOT_USER)
+                .then(
+                        reactiveRedisTemplate.opsForSet().add(key, storeId.toString())
+                )
+                .then()
+                .onErrorResume(e -> {
+                    log.error("Failed to assign store {} to server {}: {}", storeId, serverId, e.getMessage());
+                    return Mono.error(new RuntimeException("Failed to assign store to server"));
+                })
+                .doOnTerminate(() -> log.info("Store {} assigned to server {}", storeId, serverId));
+    }
+}

--- a/queue/src/main/java/com/quit/queue/application/service/StoreServerAssignmentService.java
+++ b/queue/src/main/java/com/quit/queue/application/service/StoreServerAssignmentService.java
@@ -1,7 +1,9 @@
 package com.quit.queue.application.service;
 
+import com.quit.queue.common.ApiResponse;
 import com.quit.queue.common.RoleValidationType;
 import com.quit.queue.infrastructure.util.ServerInfo;
+import com.quit.queue.presentation.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
@@ -24,14 +26,56 @@ public class StoreServerAssignmentService {
         String key = "queue:server:" + serverId + ":stores";
 
         return roleValidationService.validateUserRole(userRole, RoleValidationType.NOT_USER)
-                .then(
-                        reactiveRedisTemplate.opsForSet().add(key, storeId.toString())
-                )
+                .then(addStoreToServer(key, storeId))
+                .then()
+                .onErrorResume(e -> {
+                    if (e instanceof UnauthorizedException) {
+                        return Mono.error(new UnauthorizedException("Unauthorized role: " + userRole));
+                    } else {
+                        log.error("Failed to assign store {} to server {}: {}", storeId, serverId, e.getMessage());
+                        return Mono.error(new RuntimeException("Failed to assign store to server"));
+                    }
+                })
+                .doOnTerminate(() -> log.info("Store {} assigned to server {}", storeId, serverId));
+    }
+
+    public Mono<Void> assignStoreToSpecificServer(UUID storeId, String serverId) {
+        String key = "queue:server:server-" + serverId + ":stores";
+
+        return addStoreToServer(key, storeId)
                 .then()
                 .onErrorResume(e -> {
                     log.error("Failed to assign store {} to server {}: {}", storeId, serverId, e.getMessage());
                     return Mono.error(new RuntimeException("Failed to assign store to server"));
                 })
                 .doOnTerminate(() -> log.info("Store {} assigned to server {}", storeId, serverId));
+    }
+
+    public Mono<ApiResponse<Object>> changeStoreAssignment(UUID storeId, String fromServerId, String toServerId, String userRole) {
+        return roleValidationService.validateUserRole(userRole, RoleValidationType.MASTER)
+                .then(unassignStoreFromServer(storeId, fromServerId))
+                .then(assignStoreToSpecificServer(storeId, toServerId))
+                .then(Mono.just(ApiResponse.success("Store assignment changed successfully")))
+                .onErrorResume(e -> {
+                    if (e instanceof UnauthorizedException) {
+                        return Mono.error(new UnauthorizedException("Unauthorized role: " + userRole));
+                    } else {
+                        log.error("Failed to change assignment for store {} from server {} to {}: {}", storeId, fromServerId, toServerId, e.getMessage());
+                        return Mono.error(new RuntimeException("Failed to change store assignment to server"));
+                    }
+                })
+                .doOnTerminate(() -> log.info("Store {} changed assignment from server {} to server {}", storeId, fromServerId, toServerId));
+    }
+
+
+    private Mono<Void> unassignStoreFromServer(UUID storeId, String serverId) {
+        String key = "queue:server:server-" + serverId + ":stores";
+        return reactiveRedisTemplate.opsForSet().remove(key, storeId.toString())
+                .then();
+    }
+
+    private Mono<Void> addStoreToServer(String key, UUID storeId) {
+        return reactiveRedisTemplate.opsForSet().add(key, storeId.toString())
+                .then();
     }
 }

--- a/queue/src/main/java/com/quit/queue/common/RoleValidationType.java
+++ b/queue/src/main/java/com/quit/queue/common/RoleValidationType.java
@@ -4,4 +4,5 @@ public class RoleValidationType {
     public static final int USER = 1;
     public static final int USER_OR_MASTER = 2;
     public static final int MASTER = 3;
+    public static final int NOT_USER = 11;
 }

--- a/queue/src/main/java/com/quit/queue/infrastructure/util/ServerInfo.java
+++ b/queue/src/main/java/com/quit/queue/infrastructure/util/ServerInfo.java
@@ -1,0 +1,15 @@
+package com.quit.queue.infrastructure.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServerInfo {
+
+    @Value("${server.port}")
+    private int serverPort;
+
+    public String getServerId() {
+        return "server-" + serverPort;
+    }
+}

--- a/queue/src/main/java/com/quit/queue/presentation/controller/StoreServerAssignmentController.java
+++ b/queue/src/main/java/com/quit/queue/presentation/controller/StoreServerAssignmentController.java
@@ -1,6 +1,7 @@
 package com.quit.queue.presentation.controller;
 
 import com.quit.queue.application.service.StoreServerAssignmentService;
+import com.quit.queue.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -17,5 +18,13 @@ public class StoreServerAssignmentController {
     public Mono<Void> assignStoreToServer(@PathVariable UUID storeId,
                                           @RequestHeader(value = "X-User-Role") String userRole) {
         return storeServerAssignmentService.assignStoreToServer(storeId, userRole);
+    }
+
+    @PatchMapping("/changeAssignment")
+    public Mono<ApiResponse<Object>> changeStoreAssignment(@RequestParam UUID storeId,
+                                                           @RequestParam String fromServerId,
+                                                           @RequestParam String toServerId,
+                                                           @RequestHeader(value = "X-User-Role") String userRole) {
+        return storeServerAssignmentService.changeStoreAssignment(storeId, fromServerId, toServerId, userRole);
     }
 }

--- a/queue/src/main/java/com/quit/queue/presentation/controller/StoreServerAssignmentController.java
+++ b/queue/src/main/java/com/quit/queue/presentation/controller/StoreServerAssignmentController.java
@@ -1,0 +1,21 @@
+package com.quit.queue.presentation.controller;
+
+import com.quit.queue.application.service.StoreServerAssignmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/queues/assign-store")
+@RequiredArgsConstructor
+public class StoreServerAssignmentController {
+    private final StoreServerAssignmentService storeServerAssignmentService;
+
+    @PostMapping("{storeId}")
+    public Mono<Void> assignStoreToServer(@PathVariable UUID storeId,
+                                          @RequestHeader(value = "X-User-Role") String userRole) {
+        return storeServerAssignmentService.assignStoreToServer(storeId, userRole);
+    }
+}

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -1,70 +1,74 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.quit'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2024.0.0")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
-	//kafka
-	implementation 'org.springframework.kafka:spring-kafka'
-	testImplementation 'org.springframework.kafka:spring-kafka-test'
+    //kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    // Feign Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-micrometer'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 //Q객체 경로설정
 def querydslSrcDir = 'src/main/generated'
 clean {
-	delete file(querydslSrcDir)
+    delete file(querydslSrcDir)
 }
 tasks.withType(JavaCompile) {
-	options.generatedSourceOutputDirectory = file(querydslSrcDir)
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }

--- a/store/src/main/java/com/quit/store/StoreApplication.java
+++ b/store/src/main/java/com/quit/store/StoreApplication.java
@@ -2,12 +2,14 @@ package com.quit.store;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class StoreApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(StoreApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(StoreApplication.class, args);
+    }
 
 }

--- a/store/src/main/java/com/quit/store/application/service/QueueClientService.java
+++ b/store/src/main/java/com/quit/store/application/service/QueueClientService.java
@@ -1,0 +1,7 @@
+package com.quit.store.application.service;
+
+import java.util.UUID;
+
+public interface QueueClientService {
+    void assignStoreToServer(UUID storeId, String userRole);
+}

--- a/store/src/main/java/com/quit/store/application/service/StoreService.java
+++ b/store/src/main/java/com/quit/store/application/service/StoreService.java
@@ -17,7 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
 
 import static com.quit.store.common.util.RoleValidator.Action.*;
-import static com.quit.store.presentation.exception.ErrorType.*;
+import static com.quit.store.presentation.exception.ErrorType.STORE_NOT_FOUND;
+import static com.quit.store.presentation.exception.ErrorType.USER_NOT_SAME;
 
 
 @Service
@@ -28,10 +29,13 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final RoleValidator roleValidator;
 
+    private final QueueClientService queueClientService;
+
     public CreateStoreResponse createStore(StoreDto request, String userId, String userRole) {
         roleValidator.validateRole(userRole, CREATE);
         Store store = create(request, userId);
         storeRepository.save(store);
+        queueClientService.assignStoreToServer(store.getId(), userRole);
         return CreateStoreResponse.from(store.getId());
     }
 
@@ -51,7 +55,7 @@ public class StoreService {
 
     @Transactional(readOnly = true)
     public Page<StoreResponse> searchStores(SearchStoreDto request, Pageable pageable) {
-        Page<Store> storePage =  storeRepository.findAllBySearchRequest(request, pageable);
+        Page<Store> storePage = storeRepository.findAllBySearchRequest(request, pageable);
         return storePage.map(StoreResponse::from);
     }
 

--- a/store/src/main/java/com/quit/store/infrastructure/client/QueueClient.java
+++ b/store/src/main/java/com/quit/store/infrastructure/client/QueueClient.java
@@ -1,0 +1,16 @@
+package com.quit.store.infrastructure.client;
+
+import com.quit.store.application.service.QueueClientService;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+@FeignClient(name = "queue")
+public interface QueueClient extends QueueClientService {
+
+    @PostMapping("/api/queues/assign-store/{storeId}")
+    void assignStoreToServer(@PathVariable UUID storeId, @RequestHeader(value = "X-User-Role") String userRole);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#96

## 📝작업 내용
 Redis에서 queue:server:server-{serverId}:stores 형태의 키를 사용해 서버별로 처리할 데이터를 분리
 각 키 내부에 storeId를 포함해 서버가 특정 가게의 작업만 담당하도록 역할 분배
 스케줄러 코드 수정
 서버 장애 발생 시 관리자가 가게의 담당 서버를 변경할 수 있는 API 추가
 가게 서비스에서 가게 생성 시 FeignClient로 대기열 서버에 있는 서버에 가게 배정 API 호출

## 💬리뷰 요구사항
가게 서비스에 구현한 Commit
0c225984baf4fea633f1c2f98bdbe961529c8d9f
