### PR TITLE
[feat] 예약 슬롯 캐싱 적용

### DIFF
--- a/store/src/main/java/com/quit/store/application/dto/res/GetReservationSlotResponse.java
+++ b/store/src/main/java/com/quit/store/application/dto/res/GetReservationSlotResponse.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SearchReservationSlotResponse {
+public class GetReservationSlotResponse {
     private UUID storeId;
     private UUID slotId;
     private Boolean isAvailable;
@@ -18,8 +18,8 @@ public class SearchReservationSlotResponse {
     private Integer currentCapacity;
 
     @Builder
-    private SearchReservationSlotResponse(UUID storeId, UUID slotId, Boolean isAvailable,
-                                          Integer maxCapacity, Integer currentCapacity) {
+    private GetReservationSlotResponse(UUID storeId, UUID slotId, Boolean isAvailable,
+                                       Integer maxCapacity, Integer currentCapacity) {
         this.storeId = storeId;
         this.slotId = slotId;
         this.isAvailable = isAvailable;
@@ -27,8 +27,8 @@ public class SearchReservationSlotResponse {
         this.currentCapacity = currentCapacity;
     }
 
-    public static SearchReservationSlotResponse from(ReservationSlot reservationSlot) {
-        return SearchReservationSlotResponse.builder()
+    public static GetReservationSlotResponse from(ReservationSlot reservationSlot) {
+        return GetReservationSlotResponse.builder()
                 .storeId(reservationSlot.getStore().getId())
                 .slotId(reservationSlot.getId())
                 .isAvailable(reservationSlot.getIsAvailable())

--- a/store/src/main/java/com/quit/store/application/dto/res/SearchReservationSlotResponse.java
+++ b/store/src/main/java/com/quit/store/application/dto/res/SearchReservationSlotResponse.java
@@ -1,0 +1,40 @@
+package com.quit.store.application.dto.res;
+
+import com.quit.store.domain.entity.ReservationSlot;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchReservationSlotResponse {
+    private UUID storeId;
+    private UUID slotId;
+    private Boolean isAvailable;
+    private Integer maxCapacity;
+    private Integer currentCapacity;
+
+    @Builder
+    private SearchReservationSlotResponse(UUID storeId, UUID slotId, Boolean isAvailable,
+                                          Integer maxCapacity, Integer currentCapacity) {
+        this.storeId = storeId;
+        this.slotId = slotId;
+        this.isAvailable = isAvailable;
+        this.maxCapacity = maxCapacity;
+        this.currentCapacity = currentCapacity;
+    }
+
+    public static SearchReservationSlotResponse from(ReservationSlot reservationSlot) {
+        return SearchReservationSlotResponse.builder()
+                .storeId(reservationSlot.getStore().getId())
+                .slotId(reservationSlot.getId())
+                .isAvailable(reservationSlot.getIsAvailable())
+                .maxCapacity(reservationSlot.getMaxCapacity())
+                .currentCapacity(reservationSlot.getCurrentCapacity())
+                .build();
+    }
+
+}

--- a/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
+++ b/store/src/main/java/com/quit/store/application/service/ReservationSlotService.java
@@ -5,6 +5,7 @@ import com.quit.store.application.dto.ReservationEvent;
 import com.quit.store.application.dto.ReservationSlotDto;
 import com.quit.store.application.dto.UpdateReservationSlotDto;
 import com.quit.store.application.dto.res.ReservationSlotResponse;
+import com.quit.store.application.dto.res.GetReservationSlotResponse;
 import com.quit.store.common.util.RoleValidator;
 import com.quit.store.domain.entity.ReservationSlot;
 import com.quit.store.domain.entity.Store;
@@ -13,8 +14,10 @@ import com.quit.store.domain.repository.StoreRepository;
 import com.quit.store.presentation.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +42,7 @@ public class ReservationSlotService {
     private final ReservationSlotRepository reservationSlotRepository;
     private final StoreRepository storeRepository;
     private final RoleValidator roleValidator;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional
     public ReservationSlotResponse createSingleSlot(UUID storeId, ReservationSlotDto request, String userId, String userRole) {
@@ -55,7 +59,6 @@ public class ReservationSlotService {
         roleValidator.validateRole(userRole, CREATE);
         Store store = checkStore(storeId);
         checkUser(store, userId, userRole);
-        // 기존 슬롯을 조회하여 중복을 방지
         List<ReservationSlot> existingSlots = findExistingSlots(storeId, request.getStartDate(), request.getEndDate());
         Set<String> existingSlotKeys = generateSlotKeys(existingSlots);
         List<ReservationSlot> newSlots = generateBatchSlots(request, existingSlotKeys, store);
@@ -75,6 +78,8 @@ public class ReservationSlotService {
         validateTime(slot, request.getTime());
         validateMaxCapacity(slot, request.getMaxCapacity());
         slot.update(request);
+        String cacheKey = generateCacheKey(slot);
+        redisTemplate.opsForValue().set(cacheKey, GetReservationSlotResponse.from(slot));
         return ReservationSlotResponse.from(slot);
     }
 
@@ -86,11 +91,12 @@ public class ReservationSlotService {
     }
 
     @Transactional(readOnly = true)
-    public ReservationSlotResponse getSlotByDateAndTime(UUID storeId, LocalDate date, LocalTime time) {
+    @Cacheable(cacheNames = "reservationSlot", key = "#storeId + '_' + #date.toString() + '_' + #time.toString()")
+    public GetReservationSlotResponse getSlotByDateAndTime(UUID storeId, LocalDate date, LocalTime time) {
         Store store = checkStore(storeId);
         ReservationSlot slot = reservationSlotRepository.findByDateAndTime(store.getId(), date, time)
                 .orElseThrow(() -> new CustomException(RESERVATION_SLOT_NOT_FOUND));
-        return ReservationSlotResponse.from(slot);
+        return GetReservationSlotResponse.from(slot);
     }
 
     @Transactional
@@ -102,16 +108,20 @@ public class ReservationSlotService {
         validateSlotBelongsToStore(store.getId(), slot);
         validateReservation(slot);
         slot.delete(userId);
+        String cacheKey = generateCacheKey(slot);
+        redisTemplate.delete(cacheKey);
     }
 
     @Transactional
     @KafkaListener(topics = "reservation.confirm.success", groupId = "reservation-slot", containerFactory = "kafkaReservationEventContainerFactory")
     public void increaseCapacity(ReservationEvent reservationEvent) {
         log.info(">>>>>>> increaseCapacity <<<<<<<<<");
-        ReservationSlot reservationSlot = checkSlot(reservationEvent.getReservationSlotId());
-        validateSlotIsAvailable(reservationSlot);
-        validateCapacityLimit(reservationSlot, reservationEvent.getCurrentCapacity());
-        reservationSlot.increaseCapacity(reservationEvent.getCurrentCapacity());
+        ReservationSlot slot = checkSlot(reservationEvent.getReservationSlotId());
+        validateSlotIsAvailable(slot);
+        validateCapacityLimit(slot, reservationEvent.getCurrentCapacity());
+        slot.increaseCapacity(reservationEvent.getCurrentCapacity());
+        String cacheKey = generateCacheKey(slot);
+        redisTemplate.opsForValue().set(cacheKey, GetReservationSlotResponse.from(slot));
         log.info("<<<<<<< reservation slot increased <<<<<<<<<");
     }
 
@@ -119,11 +129,17 @@ public class ReservationSlotService {
     @KafkaListener(topics = "reservation.confirm.failed", groupId = "reservation-slot", containerFactory = "kafkaReservationEventContainerFactory")
     public void restoreCapacity(ReservationEvent reservationEvent) {
         log.info(">>>>>>> restoreCapacity <<<<<<<<<");
-        ReservationSlot reservationSlot = checkSlot(reservationEvent.getReservationSlotId());
-        validateSlotIsAvailable(reservationSlot);
-        validateSufficientCapacity(reservationSlot, reservationEvent.getCurrentCapacity());
-        reservationSlot.restoreCapacity(reservationEvent.getCurrentCapacity());
+        ReservationSlot slot = checkSlot(reservationEvent.getReservationSlotId());
+        validateSlotIsAvailable(slot);
+        validateSufficientCapacity(slot, reservationEvent.getCurrentCapacity());
+        slot.restoreCapacity(reservationEvent.getCurrentCapacity());
+        String cacheKey = generateCacheKey(slot);
+        redisTemplate.opsForValue().set(cacheKey, GetReservationSlotResponse.from(slot));
         log.info("<<<<<<< reservation slot restored <<<<<<<<<");
+    }
+
+    private String generateCacheKey(ReservationSlot reservationSlot) {
+        return "reservationSlot::" + reservationSlot.getStore().getId() + "_" + reservationSlot.getDate().toString() + "_" + reservationSlot.getTime().toString();
     }
 
     private Set<String> generateSlotKeys(List<ReservationSlot> existingSlots) {

--- a/store/src/main/java/com/quit/store/infrastructure/configuration/CacheConfig.java
+++ b/store/src/main/java/com/quit/store/infrastructure/configuration/CacheConfig.java
@@ -1,5 +1,6 @@
 package com.quit.store.infrastructure.configuration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +8,9 @@ import org.springframework.data.redis.cache.CacheKeyPrefix;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -16,6 +20,33 @@ import java.time.Duration;
 @Configuration
 @EnableCaching
 public class CacheConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
 
     @Bean
     public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {

--- a/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/ReservationSlotController.java
@@ -1,6 +1,7 @@
 package com.quit.store.presentation.controller;
 
 import com.quit.store.application.dto.res.ReservationSlotResponse;
+import com.quit.store.application.dto.res.GetReservationSlotResponse;
 import com.quit.store.application.service.ReservationSlotService;
 import com.quit.store.common.dto.ApiResponse;
 import com.quit.store.common.util.PageableUtil;
@@ -65,9 +66,9 @@ public class ReservationSlotController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<ReservationSlotResponse>> getSlotByDateAndTime(@PathVariable(name = "storeId") UUID storeId,
-                                                                                     @RequestParam LocalDate date,
-                                                                                     @RequestParam LocalTime time) {
+    public ResponseEntity<ApiResponse<GetReservationSlotResponse>> getSlotByDateAndTime(@PathVariable(name = "storeId") UUID storeId,
+                                                                                        @RequestParam LocalDate date,
+                                                                                        @RequestParam LocalTime time) {
         return ResponseEntity.ok(ApiResponse.success(reservationSlotService.getSlotByDateAndTime(storeId, date, time)));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #98

## 📝작업 내용

- 예약 생성 시 예약 슬롯 조회 요청에 대한 캐싱 적용하였습니다.
    - 기존 응답 데이터에 불필요한 데이터가 많아 새로운 response 객체 생성
    - 예약 슬롯 수정 및 삭제 그리고 예약 생성 후 kafka 메세지 소비하여 현재 예약 인원에 대한 감소 및 복구 요청에도 캐싱된 데이터가 수정될 수 있게 설정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
