### PR TITLE
[feat] email 값으로 유저 정보 조회

### DIFF
--- a/store/src/main/java/com/quit/store/presentation/controller/StoreController.java
+++ b/store/src/main/java/com/quit/store/presentation/controller/StoreController.java
@@ -10,6 +10,7 @@ import com.quit.store.presentation.dto.SearchStoreRequest;
 import com.quit.store.presentation.dto.UpdateStoreRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.zookeeper.proto.RequestHeader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;

--- a/user-server/src/main/java/com/quit/user/application/dto/UserDto.java
+++ b/user-server/src/main/java/com/quit/user/application/dto/UserDto.java
@@ -8,6 +8,7 @@ public record UserDto(
         String email,
         String nickname,
         UserRoleEnum role,
+        String slackId,
         String phone,
         String birthdate,
         String address
@@ -19,6 +20,7 @@ public record UserDto(
                 user.getEmail(),
                 user.getNickname(),
                 user.getRole(),
+                user.getSlackId(),
                 user.getPhone(),
                 user.getBirthdate(),
                 user.getAddress()

--- a/user-server/src/main/java/com/quit/user/application/service/AuthService.java
+++ b/user-server/src/main/java/com/quit/user/application/service/AuthService.java
@@ -34,10 +34,14 @@ public class AuthService {
         if(userRepository.findByPhone(signupRequest.phone()).isPresent()) {
             throw new IllegalArgumentException("이미 가입된 번호입니다.");
         }
+        if(userRepository.findBySlackId(signupRequest.slackId()).isPresent()){
+            throw new IllegalArgumentException("이미 가입된 슬랙 아이디입니다.");
+        }
 
         //user 객체 생성
-        User user = User.create(signupRequest.email(), encodedPassword, signupRequest.nickname(),
+        User user = User.create(signupRequest.email(), encodedPassword, signupRequest.nickname(),signupRequest.slackId(),
                 signupRequest.phone(), signupRequest.birthdate(), signupRequest.address());
+
         userRepository.save(user);
 
         return UserDto.of(user);

--- a/user-server/src/main/java/com/quit/user/application/service/UserService.java
+++ b/user-server/src/main/java/com/quit/user/application/service/UserService.java
@@ -54,6 +54,12 @@ public class UserService {
 
     }
 
+    public UserDto getUserByEmail(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(()
+                -> new IllegalArgumentException("해당하는 ID값을 갖는 사용자가 존재하지 않습니다."));
+        return UserDto.of(user);
+    }
+
 //    사용자 정보 업데이트
     @Transactional
     public UserDto updateUser(Long id, UserDto userDto, String role, String userId) {
@@ -101,13 +107,6 @@ public class UserService {
 
     }
 
-//    MASTER 권한 or 해당 id를 갖는 USER 판별
-    private boolean hasAccess(String role, String userId, Long id) {
-        UserRoleEnum userRole = UserRoleEnum.fromRole(role);
-
-        return userRole == UserRoleEnum.MASTER ||
-                (userRole == UserRoleEnum.USER && userId.equals(id.toString()));
-    }
 
 //    권한 요청 조회
     public List<RequestRoleDto> getRequestRoles(String userId, String role, RequestStatus status) {
@@ -150,4 +149,13 @@ public class UserService {
             throw new IllegalArgumentException("권한이 없습니다.");
         }
     }
+
+//    MASTER 권한 or 해당 id를 갖는 USER 판별
+    private boolean hasAccess(String role, String userId, Long id) {
+        UserRoleEnum userRole = UserRoleEnum.fromRole(role);
+
+        return userRole == UserRoleEnum.MASTER ||
+                (userRole == UserRoleEnum.USER && userId.equals(id.toString()));
+    }
+
 }

--- a/user-server/src/main/java/com/quit/user/application/service/UserService.java
+++ b/user-server/src/main/java/com/quit/user/application/service/UserService.java
@@ -65,6 +65,7 @@ public class UserService {
             user.update(id,
                     userDto.email(),
                     userDto.nickname(),
+                    userDto.slackId(),
                     userDto.phone(),
                     userDto.birthdate(),
                     userDto.address());

--- a/user-server/src/main/java/com/quit/user/domain/model/User.java
+++ b/user-server/src/main/java/com/quit/user/domain/model/User.java
@@ -73,11 +73,13 @@ public class User extends BaseEntity {
     public void update(Long id,
                        String email,
                       String nickname,
+                      String slackId,
                       String phone,
                       String birthdate,
                       String address){
         this.email = email;
         this.nickname = nickname;
+        this.slackId = slackId;
         this.phone = phone;
         this.birthdate = birthdate;
         this.address = address;

--- a/user-server/src/main/java/com/quit/user/domain/model/User.java
+++ b/user-server/src/main/java/com/quit/user/domain/model/User.java
@@ -33,13 +33,16 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserRoleEnum role;
 
+    @Column(name = "slack_id", nullable = false )
+    private String slackId;
+
     @Column(name = "phone", nullable = false)
     private String phone;
 
     @Column(name = "birthdate", nullable = true)
     private String birthdate;
 
-    @Column(name = " address", nullable = true)
+    @Column(name = "address", nullable = true)
     private String address;
 
     @PrePersist
@@ -51,6 +54,7 @@ public class User extends BaseEntity {
     public static User create(String email,
                               String password,
                               String nickname,
+                              String slackId,
                               String phone,
                               String birthdate,
                               String address) {
@@ -58,6 +62,7 @@ public class User extends BaseEntity {
                 .email(email)
                 .password(password)
                 .nickname(nickname)
+                .slackId(slackId)
                 .role(UserRoleEnum.USER)
                 .phone(phone)
                 .birthdate(birthdate)

--- a/user-server/src/main/java/com/quit/user/infrastructure/repository/UserRepository.java
+++ b/user-server/src/main/java/com/quit/user/infrastructure/repository/UserRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     
-    Optional<Object> findByEmail(@NotBlank(message = "이메일은 필수 입력 항목입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email);
+    Optional<User> findByEmail(@NotBlank(message = "이메일은 필수 입력 항목입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email);
 
     Optional<Object> findByNickname(@NotBlank(message = "닉네임은 필수 입력 사항입니다.") String nickname);
 

--- a/user-server/src/main/java/com/quit/user/infrastructure/repository/UserRepository.java
+++ b/user-server/src/main/java/com/quit/user/infrastructure/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<Object> findByPhone(@NotBlank(message = "전화번호는 필수 입력 사항입니다.") @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 XXX-XXXX-XXXX와 같은 형식으로 입력해야합니다.") String phone);
 
     Optional<Object> findByEmailAndIsDeletedFalse(String email);
+
+    Optional<Object> findBySlackId(@NotBlank(message = "슬랙 아이디는 필수 입력 사항입니다.") String s);
 }

--- a/user-server/src/main/java/com/quit/user/presentation/controller/UserController.java
+++ b/user-server/src/main/java/com/quit/user/presentation/controller/UserController.java
@@ -40,6 +40,14 @@ public class UserController {
                                                         @RequestHeader("X-User-Id")String userId) {
         return ResponseEntity.ok(ApiResponse.success(userService.getUser(id, role, userId)));
     }
+
+    @GetMapping("/email/{email}")
+    public ResponseEntity<ApiResponse<UserDto>> getUserByEmail(@PathVariable String email,
+                                                               @RequestHeader("X-User-Role")String role,
+                                                               @RequestHeader("X-User-Id")String userId){
+
+        return ResponseEntity.ok(ApiResponse.success(userService.getUserByEmail(email)));
+    }
 //    사용자 정보 업데이트
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<UserDto>> updateUser(@PathVariable Long id,

--- a/user-server/src/main/java/com/quit/user/presentation/request/SignupRequest.java
+++ b/user-server/src/main/java/com/quit/user/presentation/request/SignupRequest.java
@@ -19,6 +19,9 @@ public record SignupRequest(
         @NotBlank(message = "닉네임은 필수 입력 사항입니다.")
         String nickname,
 
+        @NotBlank(message = "슬랙 아이디는 필수 입력 사항입니다.")
+        String slackId,
+
         @NotBlank(message = "전화번호는 필수 입력 사항입니다.")
         @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 XXX-XXXX-XXXX와 같은 형식으로 입력해야합니다.")
         String phone,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #107 

## 📝작업 내용
- User 테이블에 slackId값이 추가되었습니다.
- `/api/users/email/{email}` 을 통해 email 값을 통한 유저 정보 조회가 가능합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 따로 권한 체크를 하지 않았습니다. 혹시 필요하다면 알려주세요!
