### PR TITLE
[refactor] 대기열 추가 시 점수의 동시성 문제 해결 및 API RestFul하게 변경, 대기시 순번을 확인할 수 있는 waiting-room API 추가

### DIFF
--- a/queue/build.gradle
+++ b/queue/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/queue/src/main/java/com/quit/queue/application/scheduler/QueueCounterResetScheduler.java
+++ b/queue/src/main/java/com/quit/queue/application/scheduler/QueueCounterResetScheduler.java
@@ -1,0 +1,49 @@
+package com.quit.queue.application.scheduler;
+
+import com.quit.queue.infrastructure.util.ServerInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueCounterResetScheduler {
+    private final ServerInfo serverInfo;
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    @Scheduled(cron = "0 0 3,15 * * ?")
+    public void resetQueueCounters() {
+        String serverId = serverInfo.getServerId();
+        String storesKey = "queue:server:" + serverId + ":stores";
+
+        reactiveRedisTemplate.hasKey(storesKey)
+                .flatMap(exists -> {
+                    if (!exists) {
+                        return Mono.empty();
+                    }
+
+                    return reactiveRedisTemplate.opsForSet().members(storesKey)
+                            .flatMap(storeId -> {
+                                String counterKey = "queue:store:" + storeId + ":counter";
+                                String queueKey = "queue:store:" + storeId + ":users";
+
+                                return reactiveRedisTemplate.opsForZSet().size(queueKey)
+                                        .flatMap(size -> {
+                                            if (size == 0) {
+                                                return reactiveRedisTemplate.delete(counterKey)
+                                                        .then(Mono.empty());
+                                            }
+                                            return Mono.empty();
+                                        });
+                            })
+                            .then();
+                })
+                .doOnError(error -> log.error("Error resetting queue counters: {}", error.getMessage()))
+                .subscribe();
+    }
+}

--- a/queue/src/main/java/com/quit/queue/application/scheduler/QueueScheduler.java
+++ b/queue/src/main/java/com/quit/queue/application/scheduler/QueueScheduler.java
@@ -11,6 +11,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,40 +41,86 @@ public class QueueScheduler {
 
     private Mono<Void> processQueue(String queueKey) {
         String storeId = queueKey.split(":")[2];
+        String statusKey = "queue:store:" + storeId + ":status";
 
-        return reactiveRedisTemplate.opsForZSet().rangeWithScores(queueKey, Range.closed(0L, 499L))
-                .collectList()
-                .flatMap(entries -> {
-                    if (entries.isEmpty()) {
+        return reactiveRedisTemplate.opsForValue().setIfAbsent(statusKey, "processing")
+                .flatMap(lockAcquired -> {
+                    if (lockAcquired) {
+                        return reactiveRedisTemplate.opsForZSet().rangeWithScores(queueKey, Range.closed(0L, 499L))
+                                .collectList()
+                                .flatMap(entries -> {
+                                    if (entries.isEmpty()) {
+                                        return Mono.empty();
+                                    }
+
+                                    return Flux.fromIterable(entries)
+                                            .flatMap(entry -> {
+                                                String userId = entry.getValue();
+                                                String reservationKey = "queue:store:" + storeId + ":reservations:" + userId;
+                                                String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
+
+                                                return reactiveRedisTemplate.hasKey(refreshKey)
+                                                        .flatMap(refreshExists -> {
+                                                            if (!refreshExists) {
+                                                                return Mono.empty();
+                                                            }
+
+                                                            return reactiveRedisTemplate.opsForHash().multiGet(reservationKey, Arrays.asList("userEmail", "guestCount", "reservationDate", "reservationTime"))
+                                                                    .flatMap(values -> {
+                                                                        if (values.size() != 4 || values.contains(null)) {
+                                                                            return Mono.empty();
+                                                                        }
+
+                                                                        ReservationMessage reservationMessage = ReservationMessage.of(
+                                                                                userId, (String) values.get(0), storeId, (String) values.get(1), (String) values.get(2), (String) values.get(3));
+                                                                        return sendToReservationService(reservationMessage);
+                                                                    });
+                                                        });
+                                            })
+                                            .then(removeUsersFromQueue(queueKey, entries));
+                                })
+                                .publishOn(Schedulers.boundedElastic())
+                                .doFinally(signalType -> {
+                                    reactiveRedisTemplate.delete(statusKey).subscribe();
+                                });
+                    } else {
                         return Mono.empty();
                     }
-
-                    return Flux.fromIterable(entries)
-                            .flatMap(entry -> {
-                                String userId = entry.getValue();
-                                String reservationKey = "queue:store:" + storeId + ":reservations:" + userId;
-                                String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
-
-                                return reactiveRedisTemplate.hasKey(refreshKey)
-                                        .flatMap(refreshExists -> {
-                                            if (!refreshExists) {
-                                                return Mono.empty();
-                                            }
-
-                                            return reactiveRedisTemplate.opsForHash().multiGet(reservationKey, Arrays.asList("userEmail", "guestCount", "reservationDate", "reservationTime"))
-                                                    .flatMap(values -> {
-                                                        if (values.size() != 4 || values.contains(null)) {
-                                                            return Mono.empty();
-                                                        }
-
-                                                        ReservationMessage reservationMessage = ReservationMessage.of(
-                                                                userId, (String) values.get(0), storeId, (String) values.get(1), (String) values.get(2), (String) values.get(3));
-                                                        return sendToReservationService(reservationMessage);
-                                                    });
-                                        });
-                            })
-                            .then(removeUsersFromQueue(queueKey, entries));
                 });
+
+        // return reactiveRedisTemplate.opsForZSet().rangeWithScores(queueKey, Range.closed(0L, 499L))
+        //         .collectList()
+        //         .flatMap(entries -> {
+        //             if (entries.isEmpty()) {
+        //                 return Mono.empty();
+        //             }
+        //
+        //             return Flux.fromIterable(entries)
+        //                     .flatMap(entry -> {
+        //                         String userId = entry.getValue();
+        //                         String reservationKey = "queue:store:" + storeId + ":reservations:" + userId;
+        //                         String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
+        //
+        //                         return reactiveRedisTemplate.hasKey(refreshKey)
+        //                                 .flatMap(refreshExists -> {
+        //                                     if (!refreshExists) {
+        //                                         return Mono.empty();
+        //                                     }
+        //
+        //                                     return reactiveRedisTemplate.opsForHash().multiGet(reservationKey, Arrays.asList("userEmail", "guestCount", "reservationDate", "reservationTime"))
+        //                                             .flatMap(values -> {
+        //                                                 if (values.size() != 4 || values.contains(null)) {
+        //                                                     return Mono.empty();
+        //                                                 }
+        //
+        //                                                 ReservationMessage reservationMessage = ReservationMessage.of(
+        //                                                         userId, (String) values.get(0), storeId, (String) values.get(1), (String) values.get(2), (String) values.get(3));
+        //                                                 return sendToReservationService(reservationMessage);
+        //                                             });
+        //                                 });
+        //                     })
+        //                     .then(removeUsersFromQueue(queueKey, entries));
+        //         });
     }
 
     private Mono<Void> sendToReservationService(ReservationMessage reservation) {

--- a/queue/src/main/java/com/quit/queue/application/scheduler/QueueScheduler.java
+++ b/queue/src/main/java/com/quit/queue/application/scheduler/QueueScheduler.java
@@ -80,47 +80,11 @@ public class QueueScheduler {
                                             .then(removeUsersFromQueue(queueKey, entries));
                                 })
                                 .publishOn(Schedulers.boundedElastic())
-                                .doFinally(signalType -> {
-                                    reactiveRedisTemplate.delete(statusKey).subscribe();
-                                });
+                                .doFinally(signalType -> reactiveRedisTemplate.delete(statusKey).subscribe());
                     } else {
                         return Mono.empty();
                     }
                 });
-
-        // return reactiveRedisTemplate.opsForZSet().rangeWithScores(queueKey, Range.closed(0L, 499L))
-        //         .collectList()
-        //         .flatMap(entries -> {
-        //             if (entries.isEmpty()) {
-        //                 return Mono.empty();
-        //             }
-        //
-        //             return Flux.fromIterable(entries)
-        //                     .flatMap(entry -> {
-        //                         String userId = entry.getValue();
-        //                         String reservationKey = "queue:store:" + storeId + ":reservations:" + userId;
-        //                         String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
-        //
-        //                         return reactiveRedisTemplate.hasKey(refreshKey)
-        //                                 .flatMap(refreshExists -> {
-        //                                     if (!refreshExists) {
-        //                                         return Mono.empty();
-        //                                     }
-        //
-        //                                     return reactiveRedisTemplate.opsForHash().multiGet(reservationKey, Arrays.asList("userEmail", "guestCount", "reservationDate", "reservationTime"))
-        //                                             .flatMap(values -> {
-        //                                                 if (values.size() != 4 || values.contains(null)) {
-        //                                                     return Mono.empty();
-        //                                                 }
-        //
-        //                                                 ReservationMessage reservationMessage = ReservationMessage.of(
-        //                                                         userId, (String) values.get(0), storeId, (String) values.get(1), (String) values.get(2), (String) values.get(3));
-        //                                                 return sendToReservationService(reservationMessage);
-        //                                             });
-        //                                 });
-        //                     })
-        //                     .then(removeUsersFromQueue(queueKey, entries));
-        //         });
     }
 
     private Mono<Void> sendToReservationService(ReservationMessage reservation) {

--- a/queue/src/main/java/com/quit/queue/application/service/QueueService.java
+++ b/queue/src/main/java/com/quit/queue/application/service/QueueService.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
-import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -20,6 +19,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -44,6 +44,7 @@ public class QueueService {
                                 String reservationKey = "queue:store:" + storeId + ":reservations:" + userId;
                                 String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
                                 String userQueueKey = "queue:user:" + userId;
+                                String counterKey = "queue:store:" + storeId + ":counter";
 
                                 ReservationDto reservationDto = reservationRequest.toDTO();
 
@@ -56,29 +57,23 @@ public class QueueService {
                                                 return Mono.error(new IllegalStateException("User is already in another queue"));
                                             } else {
                                                 return reactiveRedisTemplate.opsForValue().set(userQueueKey, storeId.toString())
-                                                        .then(reactiveRedisTemplate.opsForZSet().reverseRangeWithScores(key, Range.closed(0L, 0L))
-                                                                .next()
-                                                                .map(ZSetOperations.TypedTuple::getScore)
-                                                                .switchIfEmpty(Mono.just(0.0))
-                                                                .flatMap(highestScore -> {
-                                                                    double newScore = (highestScore == 0.0) ? 1.0 : highestScore + 1;
-                                                                    return reactiveRedisTemplate.opsForZSet().add(key, userId, newScore)
-                                                                            .then(reactiveRedisTemplate.opsForHash().putAll(reservationKey, Map.of(
-                                                                                    "userEmail", userEmail,
-                                                                                    "guestCount", reservationDto.getGuestCount().toString(),
-                                                                                    "reservationDate", reservationDto.getReservationDate().toString(),
-                                                                                    "reservationTime", reservationDto.getReservationTime().toString()
-                                                                            )))
-                                                                            .then(reactiveRedisTemplate.opsForValue().set(refreshKey, String.valueOf(System.currentTimeMillis())))
-                                                                            .then(reactiveRedisTemplate.expire(refreshKey, Duration.ofMinutes(5)))
-                                                                            .then(reactiveRedisTemplate.opsForZSet().rank(key, userId))
-                                                                            .flatMap(rank -> {
-                                                                                if (rank == null) {
-                                                                                    return Mono.error(new IllegalStateException("Failed to get rank"));
-                                                                                }
-                                                                                return Mono.just(ApiResponse.success(rank + 1));
-                                                                            });
-                                                                }));
+                                                        .then(reactiveRedisTemplate.opsForValue().increment(counterKey, 1.0)
+                                                                .flatMap(newScore -> reactiveRedisTemplate.opsForZSet().add(key, userId, newScore)
+                                                                        .then(reactiveRedisTemplate.opsForHash().putAll(reservationKey, Map.of(
+                                                                                "userEmail", userEmail,
+                                                                                "guestCount", reservationDto.getGuestCount().toString(),
+                                                                                "reservationDate", reservationDto.getReservationDate().toString(),
+                                                                                "reservationTime", reservationDto.getReservationTime().toString()
+                                                                        )))
+                                                                        .then(reactiveRedisTemplate.opsForValue().set(refreshKey, String.valueOf(System.currentTimeMillis())))
+                                                                        .then(reactiveRedisTemplate.expire(refreshKey, Duration.ofMinutes(5)))
+                                                                        .then(reactiveRedisTemplate.opsForZSet().rank(key, userId))
+                                                                        .flatMap(rank -> {
+                                                                            if (rank == null) {
+                                                                                return Mono.error(new IllegalStateException("Failed to get rank"));
+                                                                            }
+                                                                            return Mono.just(ApiResponse.success(rank + 1));
+                                                                        })));
                                             }
                                         });
                             }));
@@ -98,26 +93,24 @@ public class QueueService {
     }
 
     public Mono<ApiResponse<Integer>> getUserPositionInQueueForStore(UUID storeId, String userId, String userRole) {
-        roleValidationService.validateUserRole(userRole, 2);
-
         String key = "queue:store:" + storeId + ":users";
 
-        return reactiveRedisTemplate.opsForZSet().rank(key, userId)
+        return Mono.defer(() -> roleValidationService.validateUserRole(userRole, 2))
+                .then(Mono.defer(() -> reactiveRedisTemplate.opsForZSet().rank(key, userId)))
                 .switchIfEmpty(Mono.just(-1L))
                 .flatMap(rank -> {
-                    if (rank == null || rank == -1) {
+                    if (rank == -1L) {
                         return Mono.error(new IllegalStateException("User not found in queue"));
                     }
-                    return Mono.just(ApiResponse.success(rank.intValue()));
+                    return Mono.just(ApiResponse.success(rank.intValue() + 1));
                 });
     }
 
     public Mono<ApiResponse<?>> getQueue(UUID storeId, String userRole) {
-        roleValidationService.validateUserRole(userRole, 3);
-
-        return (storeId == null)
-                ? getAllQueues().map(ApiResponse::success)
-                : getQueueForStore(storeId);
+        return roleValidationService.validateUserRole(userRole, 3)
+                .then(storeId == null
+                        ? getAllQueues().map(ApiResponse::success)
+                        : getQueueForStore(storeId));
     }
 
     private Mono<List<QueueResponse>> getAllQueues() {
@@ -158,54 +151,68 @@ public class QueueService {
     }
 
     public Mono<ApiResponse<Object>> removeUserFromQueueForStore(UUID storeId, String paramUserId, String userId, String userRole) {
-        roleValidationService.validateUserRole(userRole, 2);
-
-        final String finalUserId;
-        if (userRole.equals("ROLE_MASTER")) {
-            finalUserId = paramUserId;
-        } else {
-            finalUserId = userId;
-        }
-
-        String key = "queue:store:" + storeId + ":users";
-        String userQueueKey = "queue:user:" + finalUserId;
-        String refreshKey = "queue:store:" + storeId + ":refresh:" + finalUserId;
-
-        return reactiveRedisTemplate.opsForValue().get(userQueueKey)
-                .flatMap(currentQueue -> {
-                    if (currentQueue != null && !currentQueue.equals(storeId.toString())) {
-                        return Mono.error(new IllegalStateException("User not in the specified store queue"));
+        return roleValidationService.validateUserRole(userRole, 2)
+                .then(Mono.defer(() -> {
+                    final String finalUserId;
+                    if (userRole.equals("ROLE_MASTER")) {
+                        finalUserId = paramUserId;
+                    } else {
+                        finalUserId = userId;
                     }
 
-                    return reactiveRedisTemplate.opsForZSet().remove(key, finalUserId)
-                            .flatMap(result -> {
-                                if (result > 0) {
-                                    return reactiveRedisTemplate.delete(userQueueKey, refreshKey)
-                                            .then(Mono.just(ApiResponse.success("User removed from queue successfully")));
+                    String key = "queue:store:" + storeId + ":users";
+                    String userQueueKey = "queue:user:" + finalUserId;
+                    String refreshKey = "queue:store:" + storeId + ":refresh:" + finalUserId;
+                    String reservationKey = "queue:store:" + storeId + ":reservations:" + finalUserId;
+
+                    return reactiveRedisTemplate.opsForValue().get(userQueueKey)
+                            .flatMap(currentQueue -> {
+                                if (currentQueue != null && !currentQueue.equals(storeId.toString())) {
+                                    return Mono.error(new IllegalStateException("User not in the specified store queue"));
                                 }
-                                return Mono.error(new IllegalArgumentException("User not found in queue"));
-                            });
-                })
-                .onErrorResume(e -> Mono.just(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                        "Failed to remove user from queue: " + e.getMessage())));
+
+                                return reactiveRedisTemplate.opsForZSet().remove(key, finalUserId)
+                                        .flatMap(result -> {
+                                            if (result > 0) {
+                                                return reactiveRedisTemplate.delete(userQueueKey, refreshKey, reservationKey)
+                                                        .then(Mono.just(ApiResponse.success("User removed from queue successfully")));
+                                            }
+                                            return Mono.error(new IllegalArgumentException("User not found in queue"));
+                                        });
+                            })
+                            .onErrorResume(e -> Mono.just(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                                    "Failed to remove user from queue: " + e.getMessage())));
+                }));
     }
 
     public Mono<ApiResponse<Object>> resetQueueForStore(UUID storeId, String userRole) {
-        roleValidationService.validateUserRole(userRole, 3);
-
-        return (storeId == null) ? resetAllQueues() : resetStoreQueue(storeId);
+        return roleValidationService.validateUserRole(userRole, 3)
+                .then(storeId == null ? resetAllQueues() : resetStoreQueue(storeId));
     }
 
     private Mono<ApiResponse<Object>> resetAllQueues() {
-        return reactiveRedisTemplate.scan(ScanOptions.scanOptions().match("queue:*").count(1000).build())
-                .buffer(100)
+        Mono<Void> storeDeletion = reactiveRedisTemplate.scan(ScanOptions.scanOptions().match("queue:store:*").count(1000).build())
+                .collect(Collectors.toSet())
                 .flatMap(keys -> {
                     if (!keys.isEmpty()) {
                         return reactiveRedisTemplate.delete(Flux.fromIterable(keys).limitRate(10))
                                 .then();
                     }
                     return Mono.empty();
-                })
+                });
+
+        Mono<Void> userDeletion = reactiveRedisTemplate.scan(ScanOptions.scanOptions().match("queue:users:*").count(1000).build())
+                .collect(Collectors.toSet())
+                .flatMap(keys -> {
+                    if (!keys.isEmpty()) {
+                        return reactiveRedisTemplate.delete(Flux.fromIterable(keys).limitRate(10))
+                                .then();
+                    }
+                    return Mono.empty();
+                });
+
+        return storeDeletion
+                .then(userDeletion)
                 .then(Mono.just(ApiResponse.success("All queues have been reset successfully.")))
                 .onErrorMap(e -> new RuntimeException("Failed to reset all queues", e));
     }
@@ -246,22 +253,23 @@ public class QueueService {
     }
 
     public Mono<ApiResponse<Integer>> checkUserInQueueForStore(UUID storeId, String userId, String userRole) {
-        roleValidationService.validateUserRole(userRole, 1);
+        return roleValidationService.validateUserRole(userRole, 1)
+                .then(Mono.defer(() -> {
+                    String queueKey = "queue:store:" + storeId + ":users";
+                    String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
 
-        String queueKey = "queue:store:" + storeId + ":users";
-        String refreshKey = "queue:store:" + storeId + ":refresh:" + userId;
+                    return reactiveRedisTemplate.opsForZSet().rank(queueKey, userId)
+                            .switchIfEmpty(Mono.just(-1L))
+                            .flatMap(rank -> {
+                                if (rank == null || rank == -1) {
+                                    return Mono.error(new IllegalStateException("User not found in queue"));
+                                }
 
-        return reactiveRedisTemplate.opsForZSet().rank(queueKey, userId)
-                .switchIfEmpty(Mono.just(-1L))
-                .flatMap(rank -> {
-                    if (rank == null || rank == -1) {
-                        return Mono.error(new IllegalStateException("User not found in queue"));
-                    }
-
-                    return reactiveRedisTemplate.opsForValue().set(refreshKey, String.valueOf(System.currentTimeMillis()))
-                            .then(reactiveRedisTemplate.expire(refreshKey, Duration.ofMinutes(5)))
-                            .then(Mono.just(ApiResponse.success(rank.intValue() + 1)));
-                });
+                                return reactiveRedisTemplate.opsForValue().set(refreshKey, String.valueOf(System.currentTimeMillis()))
+                                        .then(reactiveRedisTemplate.expire(refreshKey, Duration.ofMinutes(5)))
+                                        .then(Mono.just(ApiResponse.success(rank.intValue() + 1)));
+                            });
+                }));
     }
 
 }

--- a/queue/src/main/java/com/quit/queue/presentation/controller/StoreServerAssignmentController.java
+++ b/queue/src/main/java/com/quit/queue/presentation/controller/StoreServerAssignmentController.java
@@ -20,8 +20,8 @@ public class StoreServerAssignmentController {
         return storeServerAssignmentService.assignStoreToServer(storeId, userRole);
     }
 
-    @PatchMapping("/changeAssignment")
-    public Mono<ApiResponse<Object>> changeStoreAssignment(@RequestParam UUID storeId,
+    @PatchMapping("{storeId}/server")
+    public Mono<ApiResponse<Object>> changeStoreAssignment(@PathVariable UUID storeId,
                                                            @RequestParam String fromServerId,
                                                            @RequestParam String toServerId,
                                                            @RequestHeader(value = "X-User-Role") String userRole) {

--- a/queue/src/main/java/com/quit/queue/presentation/controller/WaitingRoomController.java
+++ b/queue/src/main/java/com/quit/queue/presentation/controller/WaitingRoomController.java
@@ -1,0 +1,26 @@
+package com.quit.queue.presentation.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Slf4j
+@Controller
+public class WaitingRoomController {
+
+    @Value("${gateway.baseUrl}")
+    private String gatewayBaseUrl;
+
+    @GetMapping("api/queues/waiting-room")
+    public Mono<String> waitingRoomPage(@RequestParam UUID storeId, Model model) {
+        model.addAttribute("storeId", storeId.toString());
+        model.addAttribute("gatewayBaseUrl", gatewayBaseUrl);
+        return Mono.just("waiting-room");
+    }
+}

--- a/queue/src/main/java/com/quit/queue/presentation/controller/WaitingRoomController.java
+++ b/queue/src/main/java/com/quit/queue/presentation/controller/WaitingRoomController.java
@@ -1,10 +1,14 @@
 package com.quit.queue.presentation.controller;
 
+import com.quit.queue.application.service.RoleValidationService;
+import com.quit.queue.common.RoleValidationType;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import reactor.core.publisher.Mono;
 
@@ -12,15 +16,23 @@ import java.util.UUID;
 
 @Slf4j
 @Controller
+@RequiredArgsConstructor
 public class WaitingRoomController {
 
     @Value("${gateway.baseUrl}")
     private String gatewayBaseUrl;
 
+    private final RoleValidationService roleValidationService;
+
     @GetMapping("api/queues/waiting-room")
-    public Mono<String> waitingRoomPage(@RequestParam UUID storeId, Model model) {
-        model.addAttribute("storeId", storeId.toString());
-        model.addAttribute("gatewayBaseUrl", gatewayBaseUrl);
-        return Mono.just("waiting-room");
+    public Mono<String> waitingRoomPage(@RequestParam UUID storeId,
+                                        @RequestHeader(value = "X-User-Role") String userRole,
+                                        Model model) {
+        return roleValidationService.validateUserRole(userRole, RoleValidationType.USER)
+                .then(Mono.defer(() -> {
+                    model.addAttribute("storeId", storeId.toString());
+                    model.addAttribute("gatewayBaseUrl", gatewayBaseUrl);
+                    return Mono.just("waiting-room");
+                }));
     }
 }

--- a/queue/src/main/resources/application.yml
+++ b/queue/src/main/resources/application.yml
@@ -12,6 +12,8 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+  main:
+    web-application-type: reactive
 server:
   port: 19096
 
@@ -28,6 +30,9 @@ eureka:
 
 store:
   baseUrl: ${STORE_BASEURL}
+
+gateway:
+  baseUrl: ${GATEWAY_BASEURL}
 
 logging:
   level:

--- a/queue/src/main/resources/templates/waiting-room.html
+++ b/queue/src/main/resources/templates/waiting-room.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f5f5f5;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+        }
+
+        .message {
+            text-align: center;
+            padding: 20px;
+            font-size: 18px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+    </style>
+    <title>Queue Refresh</title>
+    <script>
+        function refreshQueue() {
+            const storeId = document.getElementById("storeId").value;
+            const gatewayUrl = document.getElementById("gatewayUrl").value;
+
+            fetch(`${gatewayUrl}/api/queues/stores/${storeId}/users/refresh`, {
+                method: 'POST'
+            })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.code === 200) {
+                        document.getElementById("status").innerText = "대기열이 갱신되었습니다.";
+                        document.getElementById("queueNumber").innerText = "현재 순번: " + data.data;
+                    } else {
+                        document.getElementById("status").innerText = "대기열 갱신에 실패했습니다.";
+                    }
+                })
+                .catch(error => {
+                    document.getElementById("status").innerText = "갱신 중 오류가 발생했습니다.";
+                });
+        }
+
+        function removeFromQueue() {
+            const storeId = document.getElementById("storeId").value;
+            const gatewayUrl = document.getElementById("gatewayUrl").value;
+
+            fetch(`${gatewayUrl}/api/queues/stores/${storeId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Authorization': 'Bearer ' + localStorage.getItem('authToken')
+                }
+            })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.code === 200) {
+                        document.getElementById("status").innerText = "대기열에서 제거되었습니다.";
+                    } else {
+                        document.getElementById("status").innerText = "대기열에서 제거하는데 실패했습니다.";
+                    }
+                })
+                .catch(error => {
+                    document.getElementById("status").innerText = "제거 중 오류가 발생했습니다.";
+                });
+        }
+
+        window.onload = function () {
+            setInterval(refreshQueue, 5000);
+        };
+    </script>
+</head>
+<body>
+<div class="message">
+    <h1>접속량이 많습니다.</h1>
+    <p>현재 순번: <span id="queueNumber">대기 중...</span></p>
+    <p id="status"></p>
+    <button onclick="removeFromQueue()">나가기</button>
+
+    <!--/*@thymesVar id="storeId" type=""*/-->
+    <input type="hidden" id="storeId" th:value="${storeId}">
+    <!--/*@thymesVar id="gatewayBaseUrl" type=""*/-->
+    <input type="hidden" id="gatewayUrl" th:value="${gatewayBaseUrl}">
+</div>
+</body>
+</html>

--- a/queue/src/main/resources/templates/waiting-room.html
+++ b/queue/src/main/resources/templates/waiting-room.html
@@ -42,7 +42,7 @@
                         document.getElementById("status").innerText = "대기열 갱신에 실패했습니다.";
                     }
                 })
-                .catch(error => {
+                .catch(_ => {
                     document.getElementById("status").innerText = "갱신 중 오류가 발생했습니다.";
                 });
         }
@@ -65,7 +65,7 @@
                         document.getElementById("status").innerText = "대기열에서 제거하는데 실패했습니다.";
                     }
                 })
-                .catch(error => {
+                .catch(_ => {
                     document.getElementById("status").innerText = "제거 중 오류가 발생했습니다.";
                 });
         }


### PR DESCRIPTION
## #️⃣연관된 이슈
#101

## 📝작업 내용
카운터 키 추가 및 INCR 명령어를 사용해 점수의 동시성 문제 해결
대기열 카운터 키를 일정 시간마다 리셋하는 스케줄러 추가
statusKey 추가로 스케줄러에서 동일 작업이 처리되지 않게 변경
서버 장애 발생 시 관리자가 가게의 담당 서버를 변경하는 API RestFul하게 변경
대기시 순번을 확인할 수 있는 waiting-room API 및 html 추가

### 스크린샷 (선택)
갱신 오류 발생시에는 오류 메시지, 완료 성공에는 완료 메시지가 나옵니다.
아래 사진은 갱신이 되어 순번이 나오다가 오류가 발생에 오류 메시지가 나온 예시입니다.
![image](https://github.com/user-attachments/assets/1f9a9b69-6ce1-4660-8232-a6d0341f57f1)
