### PR TITLE
[feat] 결제 승인 및 취소 요청 멱등키 적용

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     // prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/payment/src/main/java/com/quit/payment/application/dto/CancelPaymentDto.java
+++ b/payment/src/main/java/com/quit/payment/application/dto/CancelPaymentDto.java
@@ -1,0 +1,22 @@
+package com.quit.payment.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CancelPaymentDto {
+    private String cancelReason;
+
+    @Builder
+    private CancelPaymentDto(String cancelReason) {
+        this.cancelReason = cancelReason;
+    }
+
+    public static CancelPaymentDto from(String cancelReason) {
+        return CancelPaymentDto.builder().cancelReason(cancelReason).build();
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/application/dto/PaymentDto.java
+++ b/payment/src/main/java/com/quit/payment/application/dto/PaymentDto.java
@@ -12,19 +12,23 @@ public class PaymentDto {
     private String orderId;
     private Integer amount;
     private String paymentKey;
+    private String idempotencyKey;
 
     @Builder
-    private PaymentDto(String orderId, Integer amount, String paymentKey) {
+    private PaymentDto(String orderId, Integer amount,
+                       String paymentKey, String idempotencyKey) {
         this.orderId = orderId;
         this.amount = amount;
         this.paymentKey = paymentKey;
+        this.idempotencyKey = idempotencyKey;
     }
 
-    public static PaymentDto of(String orderId, Integer amount, String paymentKey) {
+    public static PaymentDto of(String orderId, Integer amount, String paymentKey, String idempotencyKey) {
         return PaymentDto.builder()
                 .orderId(orderId)
                 .amount(amount)
                 .paymentKey(paymentKey)
+                .idempotencyKey(idempotencyKey)
                 .build();
     }
 

--- a/payment/src/main/java/com/quit/payment/application/service/IdempotencyService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/IdempotencyService.java
@@ -19,7 +19,7 @@ public class IdempotencyService {
         redisTemplate.opsForValue().set(
                 "idempotencyKey::" + idempotencyKey,
                 paymentKey,
-                Duration.ofDays(15) // 15일간 유효
+                Duration.ofDays(15)
         );
     }
 

--- a/payment/src/main/java/com/quit/payment/application/service/IdempotencyService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/IdempotencyService.java
@@ -1,0 +1,31 @@
+package com.quit.payment.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class IdempotencyService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveIdempotencyKey(String idempotencyKey, String paymentKey) {
+        log.info(">>>>> redis 저장 <<<<<");
+        redisTemplate.opsForValue().set(
+                "idempotencyKey::" + idempotencyKey,
+                paymentKey,
+                Duration.ofDays(15) // 15일간 유효
+        );
+    }
+
+    public String getPaymentKeyByIdempotencyKey(String idempotencyKey) {
+        log.info(">>>>> redis 조회 <<<<<");
+        return redisTemplate.opsForValue().get("idempotencyKey::" + idempotencyKey);
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -37,6 +37,7 @@ public class PaymentService {
     private final ReservationGateway reservationGateway;
     private final PaymentGateway paymentGateway;
     private final KafkaProducer kafkaProducer;
+    private final IdempotencyService idempotencyService;
     private static final String PAYMENT_SUCCESS_TOPIC = "payment.create.success";
     private static final String PAYMENT_FAILED_TOPIC = "payment.create.failed";
 
@@ -49,11 +50,16 @@ public class PaymentService {
     public PaymentResponse createPayment(UUID reservationId, PaymentDto request) {
         TempPayment tempPayment = validateTempPayment(request);
         UUID retrievedReservationId = reservationGateway.getReservation(reservationId).getData();
-        log.info("reservationId= {}", retrievedReservationId);
-        ConfirmPaymentResponse response = paymentGateway.confirmPayment(request);
+        String idempotencyKey = request.getIdempotencyKey();
+        String paymentKey = idempotencyService.getPaymentKeyByIdempotencyKey(idempotencyKey);
+        if (paymentKey != null) {
+            throw new CustomException(REQUEST_ALREADY_PROCESSED);
+        }
+        ConfirmPaymentResponse response = paymentGateway.confirmPayment(idempotencyKey, request);
         log.info("Confirm payment response: {}", response);
         Payment payment = create(response, retrievedReservationId);
         paymentRepository.save(payment);
+        idempotencyService.saveIdempotencyKey(idempotencyKey, request.getPaymentKey());
         sendKafkaMessage(PAYMENT_SUCCESS_TOPIC,"paymentId:" + payment.getId(), PaymentEvent.of(retrievedReservationId, payment.getId(), payment.getAmount()));
         return PaymentResponse.from(payment);
     }

--- a/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/quit/payment/application/service/PaymentService.java
@@ -48,28 +48,26 @@ public class PaymentService {
     }
 
     public PaymentResponse createPayment(UUID reservationId, PaymentDto request) {
-        TempPayment tempPayment = validateTempPayment(request);
-        UUID retrievedReservationId = reservationGateway.getReservation(reservationId).getData();
-        String idempotencyKey = request.getIdempotencyKey();
-        String paymentKey = idempotencyService.getPaymentKeyByIdempotencyKey(idempotencyKey);
-        if (paymentKey != null) {
-            throw new CustomException(REQUEST_ALREADY_PROCESSED);
-        }
-        ConfirmPaymentResponse response = paymentGateway.confirmPayment(idempotencyKey, request);
+        checkIdempotency(request.getIdempotencyKey());
+        validateRequest(request);
+        UUID retrievedReservationId = checkReservationId(reservationId);
+        ConfirmPaymentResponse response = confirmPaymentRequest(request);
         log.info("Confirm payment response: {}", response);
         Payment payment = create(response, retrievedReservationId);
         paymentRepository.save(payment);
-        idempotencyService.saveIdempotencyKey(idempotencyKey, request.getPaymentKey());
-        sendKafkaMessage(PAYMENT_SUCCESS_TOPIC,"paymentId:" + payment.getId(), PaymentEvent.of(retrievedReservationId, payment.getId(), payment.getAmount()));
+        saveIdempotencyKey(request.getIdempotencyKey(), request.getPaymentKey());
+        publishPaymentEvent(PAYMENT_SUCCESS_TOPIC, retrievedReservationId, payment);
         return PaymentResponse.from(payment);
     }
 
     public PaymentResponse cancelPayment(UUID paymentId, UUID reservationId, CancelPaymentRequest request) {
+        checkIdempotency(request.getIdempotencyKey());
         Payment payment = validatePayment(paymentId, reservationId);
-        CancelPaymentResponse response = paymentGateway.cancelPayment(payment.getPaymentKey(), request);
+        CancelPaymentResponse response = cancelPaymentRequest(payment.getPaymentKey(), request);
         log.info("Cancel payment response: {}", response);
         payment.cancel(Status.CANCELED, request.getCancelReason());
-        sendKafkaMessage(PAYMENT_FAILED_TOPIC, "paymentId:" + payment.getId(), PaymentEvent.of(payment.getReservationId(), payment.getId(), payment.getAmount()));
+        saveIdempotencyKey(request.getIdempotencyKey(), payment.getPaymentKey());
+        publishPaymentEvent(PAYMENT_FAILED_TOPIC, payment.getReservationId(), payment);
         return PaymentResponse.from(payment);
     }
 
@@ -80,10 +78,20 @@ public class PaymentService {
         return PaymentResponse.from(payment);
     }
 
-    private TempPayment validateTempPayment(PaymentDto request) {
+    private void checkIdempotency(String idempotencyKey) {
+        String existingPaymentKey = idempotencyService.getPaymentKeyByIdempotencyKey(idempotencyKey);
+        if (existingPaymentKey != null) {
+            throw new CustomException(REQUEST_ALREADY_PROCESSED);
+        }
+    }
+
+    private void validateRequest(PaymentDto request) {
+        validateTempPayment(request);
+    }
+
+    private void validateTempPayment(PaymentDto request) {
         TempPayment tempPayment = checkTempPayment(request);
         validateAmount(tempPayment, request.getAmount());
-        return tempPayment;
     }
 
     private TempPayment checkTempPayment(PaymentDto request) {
@@ -97,6 +105,14 @@ public class PaymentService {
         }
     }
 
+    private UUID checkReservationId(UUID reservationId) {
+        return reservationGateway.getReservation(reservationId).getData();
+    }
+
+    private ConfirmPaymentResponse confirmPaymentRequest(PaymentDto request) {
+        return paymentGateway.confirmPayment(request.getIdempotencyKey(), request);
+    }
+
     private Payment create(ConfirmPaymentResponse response, UUID reservationId) {
         return Payment.of(
                 response.getTotalAmount(),
@@ -104,6 +120,27 @@ public class PaymentService {
                 response.getPaymentKey(),
                 response.getOrderId(),
                 reservationId);
+    }
+
+    private void saveIdempotencyKey(String idempotencyKey, String paymentKey) {
+        idempotencyService.saveIdempotencyKey(idempotencyKey, paymentKey);
+    }
+
+    private void publishPaymentEvent(String topic, UUID reservationId, Payment payment) {
+        sendKafkaMessage(
+                topic,
+                "paymentId:" + payment.getId(),
+                PaymentEvent.of(reservationId, payment.getId(), payment.getAmount())
+        );
+    }
+
+    private void sendKafkaMessage(String topic, String key, PaymentEvent event) {
+        try {
+            kafkaProducer.sendMessage(topic, key, event);
+        } catch (Exception e) {
+            log.error("Failed to send Kafka message: topic= {}, key= {}", topic, key);
+            throw new CustomException(KAFKA_MESSAGE_SEND_FAILED);
+        }
     }
 
     private Payment validatePayment(UUID paymentId, UUID reservationId) {
@@ -123,13 +160,8 @@ public class PaymentService {
         }
     }
 
-    private void sendKafkaMessage(String topic, String key, PaymentEvent event) {
-        try {
-            kafkaProducer.sendMessage(topic, key, event);
-        } catch (Exception e) {
-            log.error("Failed to send Kafka message: topic= {}, key= {}", topic, key);
-            throw new CustomException(KAFKA_MESSAGE_SEND_FAILED);
-        }
+    private CancelPaymentResponse cancelPaymentRequest(String paymentId, CancelPaymentRequest request) {
+        return paymentGateway.cancelPayment(request.getIdempotencyKey(), paymentId, request.toDto());
     }
 
 }

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentClient.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentClient.java
@@ -10,12 +10,14 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "PaymentClient", url = "${payment.base-url}", configuration = PaymentFeignConfig.class)
 public interface PaymentClient {
 
     @PostMapping(value = "/confirm", consumes = MediaType.APPLICATION_JSON_VALUE)
-    ConfirmPaymentResponse confirmPayment(@RequestBody PaymentDto request);
+    ConfirmPaymentResponse confirmPayment(@RequestHeader(name = "Idempotency-Key") String idempotencyKey,
+                                          @RequestBody PaymentDto request);
 
     @PostMapping(value = "/{paymentKey}/cancel", consumes = MediaType.APPLICATION_JSON_VALUE)
     CancelPaymentResponse cancelPayment(@PathVariable("paymentKey") String paymentKey,

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentClient.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentClient.java
@@ -1,10 +1,10 @@
 package com.quit.payment.infrastructure.client;
 
+import com.quit.payment.application.dto.CancelPaymentDto;
 import com.quit.payment.application.dto.PaymentDto;
 import com.quit.payment.infrastructure.configuration.PaymentFeignConfig;
 import com.quit.payment.infrastructure.dto.CancelPaymentResponse;
 import com.quit.payment.infrastructure.dto.ConfirmPaymentResponse;
-import com.quit.payment.presentation.dto.CancelPaymentRequest;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,7 +20,8 @@ public interface PaymentClient {
                                           @RequestBody PaymentDto request);
 
     @PostMapping(value = "/{paymentKey}/cancel", consumes = MediaType.APPLICATION_JSON_VALUE)
-    CancelPaymentResponse cancelPayment(@PathVariable("paymentKey") String paymentKey,
-                                        @RequestBody CancelPaymentRequest request);
+    CancelPaymentResponse cancelPayment(@RequestHeader(name = "Idempotency-Key") String idempotencyKey,
+                                        @PathVariable(name = "paymentKey") String paymentKey,
+                                        @RequestBody CancelPaymentDto request);
 
 }

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGateway.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGateway.java
@@ -1,11 +1,11 @@
 package com.quit.payment.infrastructure.client;
 
+import com.quit.payment.application.dto.CancelPaymentDto;
 import com.quit.payment.application.dto.PaymentDto;
 import com.quit.payment.infrastructure.dto.CancelPaymentResponse;
 import com.quit.payment.infrastructure.dto.ConfirmPaymentResponse;
-import com.quit.payment.presentation.dto.CancelPaymentRequest;
 
 public interface PaymentGateway {
     ConfirmPaymentResponse confirmPayment(String idempotencyKey, PaymentDto request);
-    CancelPaymentResponse cancelPayment(String paymentKey, CancelPaymentRequest request);
+    CancelPaymentResponse cancelPayment(String idempotencyKey, String paymentKey, CancelPaymentDto request);
 }

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGateway.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGateway.java
@@ -6,6 +6,6 @@ import com.quit.payment.infrastructure.dto.ConfirmPaymentResponse;
 import com.quit.payment.presentation.dto.CancelPaymentRequest;
 
 public interface PaymentGateway {
-    ConfirmPaymentResponse confirmPayment(PaymentDto request);
+    ConfirmPaymentResponse confirmPayment(String idempotencyKey, PaymentDto request);
     CancelPaymentResponse cancelPayment(String paymentKey, CancelPaymentRequest request);
 }

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGatewayImpl.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGatewayImpl.java
@@ -1,9 +1,9 @@
 package com.quit.payment.infrastructure.client;
 
+import com.quit.payment.application.dto.CancelPaymentDto;
 import com.quit.payment.application.dto.PaymentDto;
 import com.quit.payment.infrastructure.dto.CancelPaymentResponse;
 import com.quit.payment.infrastructure.dto.ConfirmPaymentResponse;
-import com.quit.payment.presentation.dto.CancelPaymentRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,8 +19,8 @@ public class PaymentGatewayImpl implements PaymentGateway {
     }
 
     @Override
-    public CancelPaymentResponse cancelPayment(String paymentKey, CancelPaymentRequest request) {
-        return paymentClient.cancelPayment(paymentKey, request);
+    public CancelPaymentResponse cancelPayment(String idempotencyKey, String paymentKey, CancelPaymentDto request) {
+        return paymentClient.cancelPayment(idempotencyKey, paymentKey, request);
     }
 
 }

--- a/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGatewayImpl.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/client/PaymentGatewayImpl.java
@@ -14,8 +14,8 @@ public class PaymentGatewayImpl implements PaymentGateway {
     private final PaymentClient paymentClient;
 
     @Override
-    public ConfirmPaymentResponse confirmPayment(PaymentDto request) {
-        return paymentClient.confirmPayment(request);
+    public ConfirmPaymentResponse confirmPayment(String idempotencyKey, PaymentDto request) {
+        return paymentClient.confirmPayment(idempotencyKey, request);
     }
 
     @Override

--- a/payment/src/main/java/com/quit/payment/infrastructure/redis/CacheConfig.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/redis/CacheConfig.java
@@ -1,0 +1,46 @@
+package com.quit.payment.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisProperties.getHost());
+        redisStandaloneConfiguration.setPort(redisProperties.getPort());
+        redisStandaloneConfiguration.setPassword(redisProperties.getPassword());
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofDays(15))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+
+}

--- a/payment/src/main/java/com/quit/payment/infrastructure/redis/RedisProperties.java
+++ b/payment/src/main/java/com/quit/payment/infrastructure/redis/RedisProperties.java
@@ -1,0 +1,16 @@
+package com.quit.payment.infrastructure.redis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisProperties {
+    private String host;
+    private int port;
+    private String password;
+}

--- a/payment/src/main/java/com/quit/payment/presentation/dto/CancelPaymentRequest.java
+++ b/payment/src/main/java/com/quit/payment/presentation/dto/CancelPaymentRequest.java
@@ -1,5 +1,6 @@
 package com.quit.payment.presentation.dto;
 
+import com.quit.payment.application.dto.CancelPaymentDto;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,5 +13,12 @@ public class CancelPaymentRequest {
 
     @NotNull(message = "PAYMENT_CANCEL_REASON_EMPTY")
     private String cancelReason;
+
+    @NotNull(message = "PAYMENT_IDEMPOTENCY_KEY_EMPTY")
+    private String idempotencyKey;
+
+    public CancelPaymentDto toDto() {
+        return CancelPaymentDto.from(this.cancelReason);
+    }
 
 }

--- a/payment/src/main/java/com/quit/payment/presentation/dto/CreatePaymentRequest.java
+++ b/payment/src/main/java/com/quit/payment/presentation/dto/CreatePaymentRequest.java
@@ -22,11 +22,15 @@ public class CreatePaymentRequest {
     @NotNull(message = "PAYMENT_KEY_EMPTY")
     private String paymentKey;
 
+    @NotNull(message = "PAYMENT_IDEMPOTENCY_KEY_EMPTY")
+    private String idempotencyKey;
+
     public PaymentDto toDto() {
         return PaymentDto.of(
                 this.orderId,
                 this.amount,
-                this.paymentKey
+                this.paymentKey,
+                this.idempotencyKey
         );
     }
 

--- a/payment/src/main/java/com/quit/payment/presentation/exception/ErrorType.java
+++ b/payment/src/main/java/com/quit/payment/presentation/exception/ErrorType.java
@@ -21,6 +21,7 @@ public enum ErrorType {
     PAYMENT_KEY_EMPTY(BAD_REQUEST, "결제 외주사 결제키가 존재하지 않습니다."),
     PAYMENT_AMOUNT_EMPTY(BAD_REQUEST, "결제 금액이 존재하지 않습니다."),
     PAYMENT_AMOUNT_INVALID(BAD_REQUEST, "결제 금액이 유효하지 않습니다."),
+    PAYMENT_IDEMPOTENCY_KEY_EMPTY(BAD_REQUEST, "멱등키가 존재하지 않습니다."),
 
     RESERVATION_ID_MISMATCH(BAD_REQUEST, "결제 데이터와 예약 ID가 일치하지 않습니다."),
 
@@ -29,6 +30,8 @@ public enum ErrorType {
     FEIGN_CLIENT_INVALID_REQUEST(BAD_REQUEST, "FeignClient 요청에서 잘못된 요청이 발생했습니다."),
     FEIGN_CLIENT_RESOURCE_NOT_FOUND(NOT_FOUND, "FeignClient 요청에서 리소스를 찾을 수 없습니다."),
     FEIGN_CLIENT_UNKNOWN_ERROR(INTERNAL_SERVER_ERROR, "FeignClient 요청 중 알 수 없는 에러가 발생했습니다."),
+
+    REQUEST_ALREADY_PROCESSED(CONFLICT, "이미 처리된 요청입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -19,7 +19,12 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}
 server:
   port: 19095
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #125 

## 📝작업 내용

- 결제 승인 및 취소 요청 시 헤더에 멱등키를 포함하여 요청하여 동일한 요청에 멱등성 보장
    - 요청 시 전달받은 멱등키를 redis 에서 조회 하여 존재할 경우 예외처리
- redis 에 `idempotencyKey : paymentKey` 로 저장하여 관리
- TTL 15일 설정
  <img width="787" alt="스크린샷 2025-01-21 오전 12 28 09" src="https://github.com/user-attachments/assets/5ceaec8f-6885-48ee-8696-d316a20cd96c" />
  


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
