### PR TITLE
[feat] 가게 서비스에 캐싱 적용

### DIFF
--- a/store/src/main/java/com/quit/store/application/service/StoreService.java
+++ b/store/src/main/java/com/quit/store/application/service/StoreService.java
@@ -10,7 +10,9 @@ import com.quit.store.domain.repository.StoreRepository;
 import com.quit.store.presentation.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -41,6 +43,7 @@ public class StoreService {
         return CreateStoreResponse.from(store.getId());
     }
 
+    @CachePut(cacheNames = "storeDetails", key = "'storeId:' + #storeId")
     public StoreResponse updateStore(UUID storeId, StoreDto request, String userId, String userRole) {
         roleValidator.validateRole(userRole, UPDATE);
         Store store = checkStore(storeId);
@@ -50,6 +53,7 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "storeDetails", key = "'storeId:' + #storeId")
     public StoreResponse getStore(UUID storeId) {
         Store store = checkStore(storeId);
         return StoreResponse.from(store);
@@ -61,7 +65,10 @@ public class StoreService {
         return storePage.map(StoreResponse::from);
     }
 
-    @CacheEvict(cacheNames = "store", key = "args[0]")
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "storeDetails", key = "'storeId:' + #storeId"),
+            @CacheEvict(cacheNames = "storeExistence", key = "'storeId:' + #storeId")
+    })
     public void deleteStore(UUID storeId, String userId, String userRole) {
         roleValidator.validateRole(userRole, STORE_DELETE);
         Store store = checkStore(storeId);
@@ -69,7 +76,7 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(cacheNames = "store", key = "args[0]")
+    @Cacheable(cacheNames = "storeExistence", key = "'storeId:' + #storeId")
     public boolean getStoreForInternal(UUID storeId) {
         return storeRepository.existsByIdAndIsDeletedFalse(storeId);
     }

--- a/store/src/main/java/com/quit/store/infrastructure/redis/CacheConfig.java
+++ b/store/src/main/java/com/quit/store/infrastructure/redis/CacheConfig.java
@@ -1,5 +1,11 @@
 package com.quit.store.infrastructure.redis;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -33,23 +39,32 @@ public class CacheConfig {
     }
 
     @Bean
-    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        ObjectMapper objectMapperWithTypeValidator = new ObjectMapper();
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+        objectMapperWithTypeValidator
+                .findAndRegisterModules()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL)
+                .registerModule(new JavaTimeModule());
 
-        RedisCacheConfiguration configuration = RedisCacheConfiguration
+        RedisCacheConfiguration configurationWithTypeValidator = RedisCacheConfiguration
                 .defaultCacheConfig()
                 .disableCachingNullValues()
                 .entryTtl(Duration.ofHours(1))
                 .computePrefixWith(CacheKeyPrefix.simple())
-                .serializeKeysWith(
-                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
-                )
                 .serializeValuesWith(
-                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapperWithTypeValidator))
                 );
 
         return RedisCacheManager
                 .builder(redisConnectionFactory)
-                .cacheDefaults(configuration)
+                .cacheDefaults(configurationWithTypeValidator)
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #133 

## 📝작업 내용

- 기존에 내부용 가게 검증 조회에만 캐싱을 적용하였는데 확장하여 클라이언트가 사용하는 가게 단 건 조회에도 적용하였습니다.
- cache-aside 전략 활용하여 캐싱 적용
    - 응답 시간 기준 
        - 캐싱 미적용시 평균 응답 시간 = 15ms, 캐싱 적용시 평균 응답 시간 = 8ms 
        -  **응답 시간 약 46.7% 감소**
    - 처리량 기준 
        - 캐싱 미적용시 처리량 = 3104.6 req/sec, 캐싱 적용시 처리량 = 5586.6 req/sec
        -  **처리량 약 80% 증가**
    
### 스크린샷 (선택)
- jmeter 테스트 (스레드수: 50, Loop Count: 20,  Ramp-Up Period: 0초, 총 요청 수: 10,000건) 
<img width="1101" alt="스크린샷 2025-01-23 오전 2 07 55" src="https://github.com/user-attachments/assets/3edcb53b-31ea-4ce3-a6b5-ea01c8410846" />
<img width="1097" alt="스크린샷 2025-01-23 오전 2 09 44" src="https://github.com/user-attachments/assets/635f9837-a39a-4e7a-9cd6-0e6245ff389a" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
