### PR TITLE
[refactor] 비동기 스케줄러 처리 방식 개선

### DIFF
--- a/queue/src/main/java/com/quit/queue/application/scheduler/QueueCounterResetScheduler.java
+++ b/queue/src/main/java/com/quit/queue/application/scheduler/QueueCounterResetScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Slf4j
 @Service
@@ -21,29 +22,33 @@ public class QueueCounterResetScheduler {
         String serverId = serverInfo.getServerId();
         String storesKey = "queue:server:" + serverId + ":stores";
 
-        reactiveRedisTemplate.hasKey(storesKey)
-                .flatMap(exists -> {
-                    if (!exists) {
-                        return Mono.empty();
-                    }
+        Mono.fromRunnable(() -> {
+                    reactiveRedisTemplate.hasKey(storesKey)
+                            .flatMap(exists -> {
+                                if (!exists) {
+                                    return Mono.empty();
+                                }
 
-                    return reactiveRedisTemplate.opsForSet().members(storesKey)
-                            .flatMap(storeId -> {
-                                String counterKey = "queue:store:" + storeId + ":counter";
-                                String queueKey = "queue:store:" + storeId + ":users";
+                                return reactiveRedisTemplate.opsForSet().members(storesKey)
+                                        .flatMap(storeId -> {
+                                            String counterKey = "queue:store:" + storeId + ":counter";
+                                            String queueKey = "queue:store:" + storeId + ":users";
 
-                                return reactiveRedisTemplate.opsForZSet().size(queueKey)
-                                        .flatMap(size -> {
-                                            if (size == 0) {
-                                                return reactiveRedisTemplate.delete(counterKey)
-                                                        .then(Mono.empty());
-                                            }
-                                            return Mono.empty();
-                                        });
+                                            return reactiveRedisTemplate.opsForZSet().size(queueKey)
+                                                    .flatMap(size -> {
+                                                        if (size == 0) {
+                                                            return reactiveRedisTemplate.delete(counterKey)
+                                                                    .then(Mono.empty());
+                                                        }
+                                                        return Mono.empty();
+                                                    });
+                                        })
+                                        .then();
                             })
-                            .then();
+                            .doOnError(error -> log.error("Error resetting queue counters: {}", error.getMessage()))
+                            .subscribe();
                 })
-                .doOnError(error -> log.error("Error resetting queue counters: {}", error.getMessage()))
+                .subscribeOn(Schedulers.boundedElastic())
                 .subscribe();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#158

## 📝작업 내용
동기인 스케줄러로 작동되던 QueueCounterResetScheduler를
스케줄러를 사용하지만 내부에서 비동기로 실행하고 별도의 쓰레드 풀에서 실행해 실제 작업을 비동기로 처리

Quartz 스케줄러도 있지만 현재 하루에 2번만 실행되기 때문에 간단한 방법을 사용
